### PR TITLE
Updated ApprovalTests and doctest due to problems with MacOS

### DIFF
--- a/cpp/tests/test_statement.cpp
+++ b/cpp/tests/test_statement.cpp
@@ -1,7 +1,7 @@
 #include "statement.h"
 
 #include "json.hpp"
-#include "doctest.h"
+#include "doctest/doctest.h"
 #include "ApprovalTests.hpp"
 
 #include <iostream>
@@ -10,7 +10,7 @@ namespace
 {
     std::string get_adjacent_file(const std::string& filename)
     {
-        return ApprovalTestNamer().getDirectory() + filename;
+        return ApprovalTests::ApprovalTestNamer().getDirectory() + filename;
     }
 
     nlohmann::json read_json_file(const std::string& filename)
@@ -32,7 +32,7 @@ TEST_CASE("test_example_statement")
     auto invoice = read_json_file(get_adjacent_file("invoice.json"));
     auto plays = read_json_file(get_adjacent_file("plays.json"));
 
-    Approvals::verify(statement(invoice, plays));
+    ApprovalTests::Approvals::verify(statement(invoice, plays));
 }
 
 TEST_CASE("test_statement_with_new_play_types")

--- a/cpp/third_party/ApprovalTests.hpp
+++ b/cpp/third_party/ApprovalTests.hpp
@@ -1,233 +1,382 @@
-// Approval Tests version v.4.0.0
+// ApprovalTests.cpp version v.10.12.2
 // More information at: https://github.com/approvals/ApprovalTests.cpp
-#include <stdexcept>
+//
+// Copyright (c) 2022 Llewellyn Falco and Clare Macrae. All rights reserved.
+//
+// Distributed under the Apache 2.0 License
+// See https://opensource.org/licenses/Apache-2.0
+
+//----------------------------------------------------------------------
+// Welcome to Approval Tests.
+//
+// If you experience linker errors about missing symbols, it means
+// you have forgotten to configure your test framework for Approval Tests.
+//
+// For help with this, please see:
+//     https://github.com/approvals/ApprovalTests.cpp/blob/master/doc/TroubleshootingMisconfiguredMain.md
+//----------------------------------------------------------------------
+
+// ******************** From: ApprovalTests.hpp
+#ifndef APPROVAL_TESTS_CPP_APPROVALS_HPP
+#define APPROVAL_TESTS_CPP_APPROVALS_HPP
+
+// This file is machine-generated. Do not edit.
+
+
+// ******************** From: ApprovalTestsVersion.h
+
+#define APPROVAL_TESTS_VERSION_MAJOR 10
+#define APPROVAL_TESTS_VERSION_MINOR 12
+#define APPROVAL_TESTS_VERSION_PATCH 2
+#define APPROVAL_TESTS_VERSION_STR "10.12.2"
+
+#define APPROVAL_TESTS_VERSION                                                           \
+    (APPROVAL_TESTS_VERSION_MAJOR * 10000 + APPROVAL_TESTS_VERSION_MINOR * 100 +         \
+     APPROVAL_TESTS_VERSION_PATCH)
+
+// ******************** From: Reporter.h
+
 #include <string>
-#include <algorithm>
-#include <sstream>
-#include <fstream>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <memory>
-#include <vector>
-#include <functional>
-#include <iostream>
-#include <stdlib.h>
-#include <numeric>
-#include <stack>
-#include <exception>
-#include <map>
-#include <ostream>
- // ******************** From: Blocker.h
-#ifndef APPROVALTESTS_CPP_BLOCKER_H
-#define APPROVALTESTS_CPP_BLOCKER_H
 
-class Blocker
+namespace ApprovalTests
 {
-public:
-    virtual ~Blocker() = default;
-    virtual bool isBlockingOnThisMachine() const = 0;
-};
-
-#endif 
-
- // ******************** From: Macros.h
-#ifndef APPROVALTESTS_CPP_MACROS_H
-#define APPROVALTESTS_CPP_MACROS_H
-
-
-
-#define APPROVAL_TESTS_MACROS_STATIC(type, name, defaultValue) \
-static type &name(type *value = NULL) { \
-    static type *staticValue; \
-    if (value != NULL) \
-    { \
-        staticValue = value; \
-    } \
-    if (staticValue == NULL) \
-    { \
-        staticValue = defaultValue; \
-    } \
-    if ( staticValue == nullptr ) \
-    { \
-        const char* helpMessage = "The variable in " #name "() is not initialised"; \
-        throw std::runtime_error( helpMessage ); \
-    } \
-    return *staticValue; \
+    class Reporter
+    {
+    public:
+        virtual ~Reporter() = default;
+        virtual bool report(std::string received, std::string approved) const = 0;
+    };
 }
 
+// ******************** From: ReporterFactory.h
 
 
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
 
-#define APPROVAL_TESTS_UNUSED(expr) do { (void)(expr); } while (0)
-
-
-
-#endif 
-
- // ******************** From: StringUtils.h
-
-
-#ifndef APPROVALTESTS_CPP_STRINGUTILS_H
-#define APPROVALTESTS_CPP_STRINGUTILS_H
-
-
-class StringUtils
+namespace ApprovalTests
 {
-public:
-    static std::string replaceAll(std::string inText, const std::string& find, const std::string& replaceWith) {
-        size_t start_pos = 0;
-        while ((start_pos = inText.find(find, start_pos)) != std::string::npos) {
-            inText.replace(start_pos, find.length(), replaceWith);
-            start_pos += replaceWith.length(); 
-        }
-        return inText;
-    }
+    class ReporterFactory
+    {
+    public:
+        using Reporters =
+            std::map<std::string, std::function<std::unique_ptr<Reporter>()>>;
 
-    static bool contains(std::string inText, const std::string& find)
-    {
-        return inText.find(find, 0) != std::string::npos;
-    }
+        ReporterFactory();
 
-    static std::string toLower(std::string inText)
+        std::vector<std::string> allSupportedReporterNames() const;
+
+        std::unique_ptr<Reporter> createReporter(const std::string& reporterName) const;
+
+        std::string findReporterName(const std::string& osPrefix,
+                                     const std::string& reporterName) const;
+
+    private:
+        static Reporters createMap();
+
+        Reporters map;
+    };
+}
+
+// ******************** From: DiffInfo.h
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace ApprovalTests
+{
+    enum class Type
     {
-        std::string copy(inText);
-        std::transform(inText.begin(), inText.end(), copy.begin(),
-          [](char c){ return static_cast<char>(::tolower(c)); });
-        return copy;
-    }
-    
-    static bool endsWith(std::string value, std::string ending)
+        TEXT,
+        IMAGE,
+        TEXT_AND_IMAGE
+    };
+
+    struct DiffInfo
     {
-        if (ending.size() > value.size())
+        static std::string receivedFileTemplate();
+
+        static std::string approvedFileTemplate();
+
+        static std::string programFileTemplate();
+
+        static std::string getDefaultArguments();
+
+        DiffInfo(std::string program_, Type type_);
+
+        DiffInfo(std::string program_, std::string arguments_, Type type_);
+
+        std::string program;
+        std::string arguments;
+        Type type;
+
+        static std::vector<std::string> getProgramFileLocations();
+
+        std::string getProgramForOs() const;
+    };
+}
+
+// ******************** From: DiffPrograms.h
+
+
+namespace ApprovalTests
+{
+    namespace DiffPrograms
+    {
+        namespace Mac
         {
-            return false;
+            DiffInfo DIFF_MERGE();
+
+            DiffInfo ARAXIS_MERGE();
+
+            DiffInfo BEYOND_COMPARE();
+
+            DiffInfo KALEIDOSCOPE();
+
+            DiffInfo SUBLIME_MERGE();
+
+            DiffInfo KDIFF3();
+
+            DiffInfo P4MERGE();
+
+            DiffInfo TK_DIFF();
+
+            DiffInfo VS_CODE();
+
+            DiffInfo CLION();
         }
-        return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
-    }
 
-    template<typename T>
-    static std::string toString(const T& contents)
-    {
-        std::stringstream s;
-        s << contents;
-        return s.str();
-    }
-
-};
-#endif 
-
- // ******************** From: ApprovalWriter.h
-#ifndef APPROVALTESTS_CPP_APPROVALWRITER_H
-#define APPROVALTESTS_CPP_APPROVALWRITER_H
-
-class ApprovalWriter
-{
-public:
-    virtual std::string getFileExtensionWithDot() = 0;
-    virtual void write(std::string path) = 0;
-    virtual void cleanUpReceived(std::string receivedPath) = 0;
-};
-
-#endif 
-
- // ******************** From: StringWriter.h
-#ifndef APPROVALTESTS_CPP_STRINGWRITER_H
-#define APPROVALTESTS_CPP_STRINGWRITER_H
-
-
-class StringWriter : public ApprovalWriter
-{
-private:
-    std::string s;
-    std::string ext;
-
-public:
-    StringWriter( std::string contents, std::string fileExtensionWithDot = ".txt" )
-        : s( contents ), ext( fileExtensionWithDot ) {}
-
-    std::string getFileExtensionWithDot() override
-    {
-        return ext;
-    }
-
-    void write( std::string path ) override
-    {
-        std::ofstream out( path.c_str(), std::ofstream::out );
-        if ( ! out)
+        namespace Linux
         {
-            throw std::runtime_error("Unable to write file: " + path);
+            DiffInfo SUBLIME_MERGE_SNAP();
+
+            DiffInfo SUBLIME_MERGE_FLATPAK();
+
+            DiffInfo SUBLIME_MERGE_REPOSITORY_PACKAGE();
+
+            DiffInfo SUBLIME_MERGE_DIRECT_DOWNLOAD();
+
+            // More ideas available from: https://www.tecmint.com/best-linux-file-diff-tools-comparison/
+            DiffInfo KDIFF3();
+
+            DiffInfo MELD();
+
+            DiffInfo BEYOND_COMPARE();
         }
-        this->Write( out );
-        out.close();
-    }
 
-    void Write( std::ostream &out )
+        namespace Windows
+        {
+            DiffInfo BEYOND_COMPARE_3();
+
+            DiffInfo BEYOND_COMPARE_4();
+
+            DiffInfo TORTOISE_IMAGE_DIFF();
+
+            DiffInfo TORTOISE_TEXT_DIFF();
+
+            DiffInfo TORTOISE_GIT_IMAGE_DIFF();
+
+            DiffInfo TORTOISE_GIT_TEXT_DIFF();
+
+            DiffInfo WIN_MERGE_REPORTER();
+
+            DiffInfo ARAXIS_MERGE();
+
+            DiffInfo CODE_COMPARE();
+
+            DiffInfo SUBLIME_MERGE();
+
+            DiffInfo KDIFF3();
+
+            DiffInfo VS_CODE();
+        }
+    }
+}
+
+// ******************** From: ConvertForCygwin.h
+
+#include <string>
+
+namespace ApprovalTests
+{
+    class ConvertForCygwin
     {
-        out << s << "\n";
-    }
+    public:
+        virtual ~ConvertForCygwin() = default;
 
-    virtual void cleanUpReceived(std::string receivedPath) override {
-        remove(receivedPath.c_str());
-    }
+        virtual std::string convertProgramForCygwin(const std::string& filePath);
+
+        virtual std::string convertFileArgumentForCygwin(const std::string& filePath);
+    };
+
+    class DoNothing : public ConvertForCygwin
+    {
+    public:
+        std::string convertProgramForCygwin(const std::string& filePath) override;
+
+        std::string convertFileArgumentForCygwin(const std::string& filePath) override;
+    };
+}
+
+// ******************** From: CommandLauncher.h
+
+#include <string>
+
+namespace ApprovalTests
+{
+    // An interface to trigger execution of a command. See also SystemLauncher
+    class CommandLauncher
+    {
+    public:
+        virtual ~CommandLauncher() = default;
+        virtual bool launch(const std::string& commandLine) = 0;
+        virtual std::string getCommandLine(const std::string& commandLine) const = 0;
+    };
+}
+
+// ******************** From: CommandReporter.h
+
+#include <utility>
+#include <memory>
+
+namespace ApprovalTests
+{
+    // Generic reporter to launch arbitrary command
+    class CommandReporter : public Reporter
+    {
+    private:
+        std::string cmd;
+        std::string arguments = DiffInfo::getDefaultArguments();
+        CommandLauncher* l;
+        std::shared_ptr<ConvertForCygwin> converter;
+
+        std::string assembleFullCommand(const std::string& received,
+                                        const std::string& approved) const;
+
+    protected:
+        CommandReporter(std::string command, CommandLauncher* launcher);
+
+        CommandReporter(std::string command, std::string args, CommandLauncher* launcher);
+
+    public:
+        static bool exists(const std::string& command);
+
+        bool report(std::string received, std::string approved) const override;
+
+        std::string getCommandLine(const std::string& received,
+                                   const std::string& approved) const;
+
+    public:
+        void checkForCygwin();
+
+        // Seam for testing
+        void useCygwinConversions(bool useCygwin);
+    };
+}
+
+// ******************** From: ApprovalsMacroDefaults.h
+
+// This file intentionally left blank.
+
+// ******************** From: Macros.h
 
 
-};
+// Use this in places where we have parameters that are sometimes unused,
+// e.g. because of #if
+// See https://stackoverflow.com/a/1486931/104370
+#define APPROVAL_TESTS_UNUSED(expr)                                                      \
+    do                                                                                   \
+    {                                                                                    \
+        (void)(expr);                                                                    \
+    } while (0)
+
+#if __cplusplus >= 201703L
+#define APPROVAL_TESTS_NO_DISCARD [[nodiscard]]
+#else
+#define APPROVAL_TESTS_NO_DISCARD
 #endif
 
- // ******************** From: FileUtils.h
+#if (__cplusplus >= 201402L)
+#define APPROVAL_TESTS_DEPRECATED(text) [[deprecated(text)]]
+#define APPROVAL_TESTS_DEPRECATED_CPP11(text)
+#else
+#define APPROVAL_TESTS_DEPRECATED(text)
+#define APPROVAL_TESTS_DEPRECATED_CPP11(text)                                            \
+    MoreHelpMessages::deprecatedFunctionCalled(text, __FILE__, __LINE__);
+#endif
 
+#define APPROVAL_TESTS_REGISTER_MAIN_DIRECTORY                                           \
+    auto approval_tests_registered_main_directory =                                      \
+        ApprovalTests::TestName::registerRootDirectoryFromMainFile(__FILE__);
 
+// ******************** From: EmptyFileCreatorFactory.h
 
+#include <functional>
+#include <string>
 
-#ifndef APPROVALTESTS_CPP_FILEUTILS_H
-#define APPROVALTESTS_CPP_FILEUTILS_H
+namespace ApprovalTests
+{
+    using EmptyFileCreator = std::function<void(std::string)>;
 
-
-class FileUtils {
-public:
-    static bool fileExists(std::string path)
+    class EmptyFileCreatorFactory
     {
-        struct stat info;
-        return stat( path.c_str(), &info ) == 0;
-    }
+    public:
+        static void defaultCreator(std::string fullFilePath);
+        static EmptyFileCreator currentCreator;
+    };
+}
 
-    static int fileSize(std::string path) {
-        struct stat statbuf;
-        int stat_ok = stat(path.c_str(), &statbuf);
+// ******************** From: EmptyFileCreatorDisposer.h
 
-        if (stat_ok == -1) {
-            return -1;
-        }
 
-        return int(statbuf.st_size);
-    }
-
-    static void ensureFileExists(std::string fullFilePath) {
-        if (!fileExists(fullFilePath)) {
-            StringWriter s("", "");
-            s.write(fullFilePath);
-        }
-    }
-
-    static std::string getExtensionWithDot(std::string filePath) {
-        std::size_t found = filePath.find_last_of(".");
-        return filePath.substr(found);
-    }
-
-    static void writeToFile(std::string filePath, std::string content)
+namespace ApprovalTests
+{
+    class APPROVAL_TESTS_NO_DISCARD EmptyFileCreatorDisposer
     {
-        std::ofstream out(filePath.c_str(), std::ios::binary | std::ofstream::out);
-        out << content;
-    }
-};
+    private:
+        EmptyFileCreator previous_result;
 
-#endif 
+    public:
+        explicit EmptyFileCreatorDisposer(EmptyFileCreator creator);
+        EmptyFileCreatorDisposer(const EmptyFileCreatorDisposer&) = default;
 
- // ******************** From: WinMinGWUtils.h
-#ifndef APPROVALTESTS_CPP_WINMINGWUTILS_H
-#define APPROVALTESTS_CPP_WINMINGWUTILS_H
+        ~EmptyFileCreatorDisposer();
+    };
+}
 
-// <SingleHpp unalterable>
+// ******************** From: FileUtils.h
+
+#include <string>
+namespace ApprovalTests
+{
+    class FileUtils
+    {
+    public:
+        static bool fileExists(const std::string& path);
+
+        static int fileSize(const std::string& path);
+
+        static EmptyFileCreatorDisposer useEmptyFileCreator(EmptyFileCreator creator);
+
+        static void ensureFileExists(const std::string& fullFilePath);
+
+        static std::string getDirectory(const std::string& filePath);
+
+        static std::string getExtensionWithDot(const std::string& filePath);
+
+        static std::string readFileThrowIfMissing(const std::string& fileName);
+
+        static std::string readFileReturnEmptyIfMissing(const std::string& fileName);
+
+        static void writeToFile(const std::string& filePath, const std::string& content);
+    };
+}
+
+// ******************** From: WinMinGWUtils.h
 
 #if (defined(__MINGW32__) || defined(__MINGW64__))
 #define APPROVAL_TESTS_MINGW
@@ -235,17 +384,16 @@ public:
 
 #ifdef APPROVAL_TESTS_MINGW
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #include <sec_api/stdlib_s.h> /* errno_t, size_t */
 
-errno_t getenv_s(
-    size_t     *ret_required_buf_size,
-    char       *buf,
-    size_t      buf_size_in_bytes,
-    const char *name
-);
+    errno_t getenv_s(size_t* ret_required_buf_size,
+                     char* buf,
+                     size_t buf_size_in_bytes,
+                     const char* name);
 
 #ifdef __cplusplus
 }
@@ -253,993 +401,3662 @@ errno_t getenv_s(
 
 #endif // APPROVAL_TESTS_MINGW
 
-// </SingleHpp>
+// ******************** From: StringMaker.h
 
-#endif 
+#include <string>
+#include <sstream>
 
- // ******************** From: SystemUtils.h
-#ifndef APPROVALTESTS_CPP_SYSTEMUTILS_H
-#define APPROVALTESTS_CPP_SYSTEMUTILS_H
+namespace ApprovalTests
+{
+    class StringMaker
+    {
+    public:
+        template <typename T> static std::string toString(const T& contents)
+        {
+            std::stringstream s;
+            s << contents;
+            return s.str();
+        }
+    };
+}
 
-// <SingleHpp unalterable>
+// ******************** From: StringUtils.h
+
+
+
+
+#include <string>
+#include <algorithm>
+#include <sstream>
+
+namespace ApprovalTests
+{
+    class StringUtils
+    {
+    public:
+        static std::string replaceAll(std::string inText,
+                                      const std::string& find,
+                                      const std::string& replaceWith);
+
+        static bool contains(const std::string& inText, const std::string& find);
+
+        static std::string toLower(std::string inText);
+
+        static bool beginsWith(std::string value, std::string beginning);
+        static bool endsWith(std::string value, std::string ending);
+
+        template <typename T> static std::string toString(const T& contents)
+        {
+            return StringMaker::toString(contents);
+        }
+
+        static std::string leftTrim(std::string s);
+
+        static std::string rightTrim(std::string s);
+
+        static std::string trim(std::string s);
+    };
+}
+
+// ******************** From: SystemUtils.h
+
 #ifdef _WIN32
-    // ReSharper disable once CppUnusedIncludeDirective
-    #include <io.h>
-    #include <windows.h>
-    #include <direct.h>
+// ReSharper disable once CppUnusedIncludeDirective
+#include <io.h>
+#include <direct.h>
 #else
-    // ReSharper disable once CppUnusedIncludeDirective
-    #include <unistd.h>
+// ReSharper disable once CppUnusedIncludeDirective
+#include <unistd.h>
 #endif
-// </SingleHpp>
 
 
+#include <stdexcept>
 
-class SystemUtils
+namespace ApprovalTests
 {
-public:
-    static bool isWindowsOs()
+    class SystemUtils
     {
-#ifdef _WIN32
-        return true;
-#else
-        return false;
-#endif
+    public:
+        static bool isWindowsOs();
 
-    }
-    
-    static bool isCygwin()
-    {
-#ifdef __CYGWIN__
-        return true;
-#else
-        return false;
-#endif
-    }
+        static bool isCygwin();
 
-    static std::string getDirectorySeparator()
-    {
-        return isWindowsOs() ? "\\" : "/";
-    }
+        static bool isMacOs();
 
-    
-    static std::string checkFilenameCase(const std::string& fullPath)
-    {
-        if (!isWindowsOs() || !FileUtils::fileExists(fullPath))
-        {
-            return fullPath;
-        }
-#ifdef _WIN32
+        static std::string getDirectorySeparator();
 
-        WIN32_FIND_DATAA findFileData;
-        HANDLE hFind = FindFirstFileA(fullPath.c_str(), &findFileData);
+        // Properly cases the filename, but not the directories, on Windows.
+        static std::string checkFilenameCase(const std::string& fullPath);
 
-        if (hFind != INVALID_HANDLE_VALUE)
-        {
-            const std::string fixedFilename = findFileData.cFileName;
-            const std::string fixedPath = 
-                StringUtils::replaceAll( fullPath, StringUtils::toLower(fixedFilename), fixedFilename );
-            FindClose(hFind);
-            return fixedPath;
-        }
+        static std::string safeGetEnvForWindows(char const* name);
+
+        static std::string safeGetEnvForNonWindows(char const* name);
+
+        //! Return the value of the environment variable, or an empty string if the variable is not set.
+        static std::string safeGetEnv(char const* name);
+
+        static std::string getMachineName();
+
+        static void makeDirectoryForWindows(const std::string& directory);
+
+        static void makeDirectoryForNonWindows(const std::string& directory);
+
+        static void makeDirectory(const std::string& directory);
+
+        static void ensureDirectoryExists(const std::string& fullDirectoryPath);
+
+        static void ensureParentDirectoryExists(const std::string& fullFilePath);
+
+        static void runSystemCommandOrThrow(const std::string& command,
+                                            bool allowNonZeroExitCodes = false);
+    };
+}
+
+// ******************** From: SystemLauncher.h
 
 
-#endif
-        return fullPath;
+#include <string>
 
-    }
-
-    static std::string safeGetEnvForWindows(char const *name)
-    {
-        APPROVAL_TESTS_UNUSED(name);
-#ifdef _WIN32
-        
-        
-        
-
-        size_t size;
-        getenv_s(&size, nullptr, 0, name);
-
-        if (size != 0)
-        {
-            std::string result;
-            result.resize(size);
-            getenv_s(&size, &*result.begin(), size, name);
-            result.pop_back();
-            return result;
-        }
-#endif
-        return std::string();
-    }
-
-    static std::string safeGetEnvForNonWindows(char const *name)
-    {
-        APPROVAL_TESTS_UNUSED(name);
-        char* p = nullptr;
-#ifndef _WIN32
-        p = getenv(name);
-#endif
-        return (p != nullptr) ? p : std::string();
-    }
-
-    
-    static std::string safeGetEnv(char const *name)
-    {
-        return isWindowsOs() ? safeGetEnvForWindows(name) : safeGetEnvForNonWindows(name);
-    }
-    
-    static std::string getMachineName()
-    {
-        auto name = safeGetEnv("COMPUTERNAME");
-        if ( ! name.empty())
-        {
-            return name;
-        }
-
-        name = safeGetEnv("HOSTNAME");
-        if ( ! name.empty())
-        {
-            return name;
-        }
-
-        return "Unknown Computer";
-    }
-
-    static void makeDirectoryForWindows(std::string directory)
-    {
-        APPROVAL_TESTS_UNUSED(directory);
-#ifdef _WIN32
-        int nError = _mkdir(directory.c_str());
-        if (nError != 0)
-        {
-            std::string helpMessage = std::string("Unable to create directory: ") + directory;
-            throw std::runtime_error( helpMessage );
-        }
-#endif
-    }
-
-    static void makeDirectoryForNonWindows(std::string directory)
-    {
-        APPROVAL_TESTS_UNUSED(directory);
-#ifndef _WIN32
-        mode_t nMode = 0733; 
-        int nError = mkdir(directory.c_str(),nMode);
-        if (nError != 0)
-        {
-            std::string helpMessage = std::string("Unable to create directory: ") + directory;
-            throw std::runtime_error( helpMessage );
-        }
-#endif
-    }
-
-    static void makeDirectory(std::string directory)
-    {
-        makeDirectoryForWindows(directory);
-        makeDirectoryForNonWindows(directory);
-    }
-
-    static void ensureDirectoryExists(std::string fullFilePath)
-    {
-        if (!FileUtils::fileExists(fullFilePath))
-        {
-            makeDirectory(fullFilePath);
-        }
-    }
-};
-#endif
-
- // ******************** From: MachineBlocker.h
-#ifndef APPROVALTESTS_CPP_MACHINEBLOCKER_H
-#define APPROVALTESTS_CPP_MACHINEBLOCKER_H
-
-
-
-class MachineBlocker : public Blocker
+namespace ApprovalTests
 {
-private:
-    std::string machineName;
-    bool block;
-
-    MachineBlocker() = delete;
-
-public:
-    MachineBlocker( const std::string& machineName, bool block ) : machineName(machineName), block(block)
+    class SystemLauncher : public CommandLauncher
     {
-    }
+    private:
+        bool useWindows_ = SystemUtils::isWindowsOs();
+        bool isForeground_ = false;
+        bool allowNonZeroExitCodes_ = false;
 
-    static MachineBlocker onMachineNamed( const std::string& machineName )
-    {
-        return MachineBlocker(machineName, true);
-    }
+    public:
+        explicit SystemLauncher(bool isForeground = false,
+                                bool allowNonZeroExitCodes = false);
 
-    static MachineBlocker onMachinesNotNamed( const std::string& machineName )
-    {
-        return MachineBlocker(machineName, false);
-    }
+        bool launch(const std::string& commandLine) override;
 
-    virtual bool isBlockingOnThisMachine() const override
-    {
-        const auto isMachine = (SystemUtils::getMachineName() == machineName);
-        return isMachine == block;
-    }
-};
+        // Seam for testing
+        void invokeForWindows(bool useWindows);
 
+        void setForeground(bool foreground);
 
-#endif 
+        void setAllowNonZeroExitCodes(bool allow);
 
- // ******************** From: FileUtilsSystemSpecific.h
-#ifndef APPROVALTESTS_CPP_FILEUTILSSYSTEMSPECIFIC_H
-#define APPROVALTESTS_CPP_FILEUTILSSYSTEMSPECIFIC_H
+        bool isForeground() const;
 
+        std::string getCommandLine(const std::string& commandLine) const override;
 
-class FileUtilsSystemSpecific
+        std::string getWindowsCommandLine(const std::string& commandLine,
+                                          bool foreground) const;
+
+        std::string getUnixCommandLine(const std::string& commandLine,
+                                       bool foreground) const;
+    };
+}
+
+// ******************** From: GenericDiffReporter.h
+
+#include <string>
+
+namespace ApprovalTests
 {
-public:
-    static std::string getCommandLineForCopy(std::string source, std::string destination, bool isWindows)
+    class GenericDiffReporter : public CommandReporter
     {
-        if (isWindows) {
-            return std::string("copy /Y ") + "\"" + source + "\" \"" + destination + "\"";
-        } else {
-            return std::string("cp ") + "\"" + source + "\" \"" + destination + "\"";
-        }
-    }
+    public:
+        SystemLauncher launcher;
 
-    static void copyFile( std::string source, std::string destination )
-    {
-        system( getCommandLineForCopy(source, destination, SystemUtils::isWindowsOs()).c_str() );
-    }
-};
-#endif
+    public:
+        explicit GenericDiffReporter(const std::string& program);
 
- // ******************** From: Reporter.h
-#ifndef APPROVALTESTS_CPP_REPORTER_H
-#define APPROVALTESTS_CPP_REPORTER_H
+        explicit GenericDiffReporter(const DiffInfo& info);
+    };
+}
+
+// ******************** From: QuietReporter.h
 
 
-
-class Reporter {
-public:
-    virtual ~Reporter() = default;
-    virtual bool report(std::string received, std::string approved) const = 0;
-};
-
-#endif
-
- // ******************** From: AutoApproveReporter.h
-#ifndef APPROVALTESTS_CPP_AUTOAPPROVEREPORTER_H
-#define APPROVALTESTS_CPP_AUTOAPPROVEREPORTER_H
-
-
-class AutoApproveReporter : public Reporter
+namespace ApprovalTests
 {
-public:
-    bool report(std::string received, std::string approved) const override
+    // A reporter that does nothing. Failing tests will still fail, but nothing will be launched.
+    class QuietReporter : public Reporter
     {
-        std::cout << "file " << approved << " automatically approved - next run should succeed\n";
-        FileUtilsSystemSpecific::copyFile( received, approved );
-        return true;
-    }
-};
+    public:
+        bool report(std::string /*received*/, std::string /*approved*/) const override;
+    };
+}
 
-#endif
-
- // ******************** From: GoogleCustomizationsFactory.h
-#ifndef APPROVALTESTS_CPP_GOOGLECUSTOMIZATIONSFACTORY_H
-#define APPROVALTESTS_CPP_GOOGLECUSTOMIZATIONSFACTORY_H
+// ******************** From: TextDiffReporter.h
 
 
+#include <memory>
+#include <iosfwd>
 
-class GoogleCustomizationsFactory
+namespace ApprovalTests
 {
-public:
-    using Comparator = std::function<bool(const std::string&, const std::string&)>;
-private:
-    using ComparatorContainer = std::vector< Comparator >;
-    APPROVAL_TESTS_MACROS_STATIC(ComparatorContainer, comparatorContainer, GoogleCustomizationsFactory::createContainer())
-
-    static ComparatorContainer* createContainer()
+    // A Reporter class that only uses text-based diff tools, with output written
+    // to the console. It provides no opportunity for interactive approving
+    // of files.
+    // It currently has a short, hard-coded list of diffing tools.
+    class TextDiffReporter : public Reporter
     {
-        auto container = new ComparatorContainer;
+    private:
+        std::unique_ptr<Reporter> m_reporter;
+        std::ostream& stream_;
 
-        auto exactNameMatching = [](std::string testFileNameWithExtension, std::string testCaseName)
+    public:
+        TextDiffReporter();
+        explicit TextDiffReporter(std::ostream& stream);
+
+        bool report(std::string received, std::string approved) const override;
+    };
+} // namespace ApprovalTests
+
+// ******************** From: Blocker.h
+
+namespace ApprovalTests
+{
+    class Blocker
+    {
+    public:
+        Blocker() = default;
+        Blocker(const Blocker&) = default;
+        Blocker(Blocker&&) = default;
+        Blocker& operator=(const Blocker&) = default;
+        Blocker& operator=(Blocker&&) = default;
+
+        virtual ~Blocker() = default;
+
+        virtual bool isBlockingOnThisMachine() const = 0;
+    };
+}
+
+// ******************** From: MachineBlocker.h
+
+#include <utility>
+
+namespace ApprovalTests
+{
+    class MachineBlocker : public Blocker
+    {
+    private:
+        std::string machineName;
+        bool block;
+
+        MachineBlocker() = delete;
+
+    public:
+        MachineBlocker(std::string machineName_, bool block_);
+
+        static MachineBlocker onMachineNamed(const std::string& machineName);
+
+        static MachineBlocker onMachinesNotNamed(const std::string& machineName);
+
+        virtual bool isBlockingOnThisMachine() const override;
+    };
+}
+
+// ******************** From: AutoApproveReporter.h
+
+
+namespace ApprovalTests
+{
+    class AutoApproveReporter : public Reporter
+    {
+    public:
+        bool report(std::string received, std::string approved) const override;
+    };
+}
+
+// ******************** From: Path.h
+
+
+#include <string>
+
+namespace ApprovalTests
+{
+    class Path
+    {
+        std::string path_;
+        std::string separator_ = SystemUtils::getDirectorySeparator();
+
+    public:
+        Path(const std::string& start);
+
+        std::string toString() const;
+        std::string toString(const std::string& directoryPathSeparator) const;
+
+        Path operator+(const std::string& addition) const;
+        Path operator/(const std::string& addition) const;
+        Path operator/(const Path addition) const;
+
+        static std::string normalizeSeparators(const std::string& path);
+        std::string removeRedundantDirectorySeparators(std::string path) const;
+    };
+}
+
+// ******************** From: ApprovalNamer.h
+
+#include <string>
+
+namespace ApprovalTests
+{
+    class ApprovalNamer
+    {
+    public:
+        virtual ~ApprovalNamer() = default;
+        virtual std::string getApprovedFile(std::string extensionWithDot) const = 0;
+        virtual std::string getReceivedFile(std::string extensionWithDot) const = 0;
+    };
+}
+
+// ******************** From: ApprovalTestNamer.h
+
+#include <vector>
+#include <stdexcept>
+
+namespace ApprovalTests
+{
+    class TestName
+    {
+    public:
+        const std::string& getFileName() const;
+        std::string getOriginalFileName();
+
+        void setFileName(const std::string& file);
+
+    private:
+        static void checkBuildConfiguration(const std::string& fileName);
+
+    public:
+        static std::string getMisconfiguredBuildHelp(const std::string& fileName);
+        static std::string checkParentDirectoriesForFile(const std::string& file);
+        static bool registerRootDirectoryFromMainFile(const std::string& file);
+        static std::string getRootDirectory();
+
+        std::vector<std::string> sections;
+        static std::string directoryPrefix;
+        static bool checkBuildConfig_;
+
+    private:
+        std::string handleBoostQuirks() const;
+        std::string findFileName(const std::string& file);
+        static std::string& rootDirectoryStorage();
+
+        std::string fileName;
+        std::string originalFileName;
+    };
+
+    class TestConfiguration
+    {
+    public:
+        std::string subdirectory;
+    };
+
+    class ApprovalTestNamer : public ApprovalNamer
+    {
+    private:
+    public:
+        ApprovalTestNamer() = default;
+
+        std::string getTestName() const;
+
+        static std::string convertToFileName(const std::string& fileName);
+
+        static TestName& getCurrentTest();
+
+        static std::string getMisconfiguredMainHelp();
+
+        // Deprecated - please use getSourceFileName
+        std::string getFileName() const;
+
+        std::string getSourceFileName() const;
+
+        std::string getTestSourceDirectory() const;
+
+        std::string getRelativeTestSourceDirectory() const;
+
+        std::string getApprovalsSubdirectory() const;
+
+        std::string getDirectory() const;
+
+        static TestName& currentTest(TestName* value = nullptr);
+
+        static TestConfiguration& testConfiguration();
+
+        virtual std::string getApprovedFile(std::string extensionWithDot) const override;
+
+        virtual std::string getReceivedFile(std::string extensionWithDot) const override;
+
+        std::string getOutputFileBaseName() const;
+
+        std::string getFullFileName(const std::string& approved,
+                                    const std::string& extensionWithDot) const;
+
+        static bool setCheckBuildConfig(bool enabled);
+    };
+}
+
+// ******************** From: SectionNameDisposer.h
+
+
+namespace ApprovalTests
+{
+    class APPROVAL_TESTS_NO_DISCARD SectionNameDisposer
+    {
+    public:
+        SectionNameDisposer(TestName& currentTest_, const std::string& scope_name);
+        SectionNameDisposer(const SectionNameDisposer&) = default;
+
+        ~SectionNameDisposer();
+
+    private:
+        TestName& currentTest;
+    };
+}
+
+// ******************** From: NamerFactory.h
+
+
+#include <string>
+
+namespace ApprovalTests
+{
+    struct NamerFactory
+    {
+        static SectionNameDisposer appendToOutputFilename(const std::string& sectionName);
+    };
+}
+
+// ******************** From: ApprovalUtils.h
+
+#include <iosfwd>
+#include <string>
+
+namespace ApprovalTests
+{
+    class ApprovalUtils
+    {
+    public:
+        static void writeHeader(std::ostream& stream, const std::string& header);
+    };
+}
+
+// ******************** From: ApprovalComparator.h
+
+#include <string>
+
+namespace ApprovalTests
+{
+    class ApprovalComparator
+    {
+    public:
+        virtual ~ApprovalComparator() = default;
+
+        virtual bool contentsAreEquivalent(std::string receivedPath,
+                                           std::string approvedPath) const = 0;
+    };
+}
+
+// ******************** From: ComparatorDisposer.h
+
+#include <map>
+#include <memory>
+#include <utility>
+
+namespace ApprovalTests
+{
+
+    using ComparatorContainer =
+        std::map<std::string, std::shared_ptr<ApprovalComparator>>;
+
+    class APPROVAL_TESTS_NO_DISCARD ComparatorDisposer
+    {
+    public:
+        ComparatorDisposer(
+            ComparatorContainer& comparators_,
+            const std::string& extensionWithDot,
+            std::shared_ptr<ApprovalTests::ApprovalComparator> previousComparator_,
+            std::shared_ptr<ApprovalTests::ApprovalComparator> newComparator);
+
+        ComparatorDisposer(const ComparatorDisposer&) = delete;
+
+        ComparatorDisposer(ComparatorDisposer&& other) noexcept;
+
+        ~ComparatorDisposer();
+
+    private:
+        // A disposer becomes inactive when it is moved from.
+        // This is done to prevent a comparator from being disposed twice.
+        bool isActive = true;
+        ComparatorContainer& comparators;
+        std::string ext_;
+        std::shared_ptr<ApprovalTests::ApprovalComparator> previousComparator;
+    };
+}
+
+// ******************** From: ComparatorFactory.h
+
+#include <memory>
+
+namespace ApprovalTests
+{
+
+    class ComparatorFactory
+    {
+    private:
+        static ComparatorContainer& comparators();
+
+    public:
+        static ComparatorDisposer
+        registerComparator(const std::string& extensionWithDot,
+                           std::shared_ptr<ApprovalComparator> comparator);
+
+        static std::shared_ptr<ApprovalComparator>
+        getComparatorForFile(const std::string& receivedPath);
+
+        static std::shared_ptr<ApprovalComparator>
+        getComparatorForFileExtensionWithDot(const std::string& fileExtensionWithDot);
+    };
+}
+
+// ******************** From: ApprovalWriter.h
+
+#include <string>
+
+namespace ApprovalTests
+{
+    class ApprovalWriter
+    {
+    public:
+        virtual ~ApprovalWriter() = default;
+        virtual std::string getFileExtensionWithDot() const = 0;
+        virtual void write(std::string path) const = 0;
+        virtual void cleanUpReceived(std::string receivedPath) const = 0;
+    };
+}
+
+// ******************** From: StringWriter.h
+
+
+namespace ApprovalTests
+{
+    class StringWriter : public ApprovalWriter
+    {
+    private:
+        std::string s;
+        std::string ext;
+
+    public:
+        explicit StringWriter(std::string contents,
+                              std::string fileExtensionWithDot = ".txt");
+
+        std::string getFileExtensionWithDot() const override;
+
+        void write(std::string path) const override;
+
+        void Write(std::ostream& out) const;
+
+        virtual void cleanUpReceived(std::string receivedPath) const override;
+    };
+}
+
+// ******************** From: FileApprover.h
+
+
+#include <memory>
+#include <functional>
+
+namespace ApprovalTests
+{
+    class FileApprover
+    {
+
+    public:
+        FileApprover() = default;
+
+        ~FileApprover() = default;
+
+        /*! \brief Register a custom comparater, which will be used to compare approved
+         *         and received files with the given extension.
+         *
+         * @param extensionWithDot A file extention, such as ".jpg"
+         * @param comparator <tt>std::shared_ptr</tt> to a ApprovalTests::ApprovalComparator
+         *                   instance
+         * @return A "Disposable" object. The caller should hold on to this object.
+         *         When it is destroyed, the customisation will be reversed.
+         *
+         * \see For more information, see
+         *      \userguide{CustomComparators,Custom Comparators}
+         */
+        static ComparatorDisposer
+        registerComparatorForExtension(const std::string& extensionWithDot,
+                                       std::shared_ptr<ApprovalComparator> comparator);
+
+        //! This overload is an implementation detail. To add a new comparator, use registerComparatorForExtension().
+        static void verify(const std::string& receivedPath,
+                           const std::string& approvedPath,
+                           const ApprovalComparator& comparator);
+
+        static void verify(const std::string& receivedPath,
+                           const std::string& approvedPath);
+
+        static void
+        verify(const ApprovalNamer& n, const ApprovalWriter& s, const Reporter& r);
+
+        static void reportAfterTryingFrontLoadedReporter(const std::string& receivedPath,
+                                                         const std::string& approvedPath,
+                                                         const Reporter& r);
+
+        using TestPassedNotification = std::function<void()>;
+        static void setTestPassedNotification(TestPassedNotification notification);
+        static void notifyTestPassed();
+
+    private:
+        static TestPassedNotification testPassedNotification_;
+    };
+}
+
+// ******************** From: FmtToString.h
+#ifdef FMT_VERSION
+namespace ApprovalTests
+{
+    class FmtToString
+    {
+    public:
+        template <typename T> static std::string toString(const T& printable)
         {
-            return StringUtils::contains(testFileNameWithExtension, testCaseName + ".");
+            (void)printable;
+            return fmt::to_string(printable);
+        }
+    };
+
+}
+#endif
+
+// ******************** From: FileNameSanitizerFactory.h
+#include <functional>
+
+namespace ApprovalTests
+{
+    using FileNameSanitizer = std::function<std::string(std::string)>;
+
+    class FileNameSanitizerFactory
+    {
+    public:
+        static bool isForbidden(char c);
+        static std::string defaultSanitizer(std::string fileName);
+        static FileNameSanitizer currentSanitizer;
+    };
+}
+
+// ******************** From: FileNameSanitizerDisposer.h
+
+
+namespace ApprovalTests
+{
+    class APPROVAL_TESTS_NO_DISCARD FileNameSanitizerDisposer
+    {
+    private:
+        FileNameSanitizer previous_result;
+
+    public:
+        explicit FileNameSanitizerDisposer(FileNameSanitizer sanitizer);
+        FileNameSanitizerDisposer(const FileNameSanitizerDisposer&) = default;
+
+        ~FileNameSanitizerDisposer();
+    };
+}
+
+// ******************** From: SubdirectoryDisposer.h
+
+
+#include <string>
+
+namespace ApprovalTests
+{
+    //! Implementation detail of Approvals::useApprovalsSubdirectory()
+    class APPROVAL_TESTS_NO_DISCARD SubdirectoryDisposer
+    {
+    private:
+        std::string previous_result;
+
+    public:
+        explicit SubdirectoryDisposer(std::string subdirectory);
+        SubdirectoryDisposer(const SubdirectoryDisposer&) = default;
+
+        ~SubdirectoryDisposer();
+    };
+}
+
+// ******************** From: DefaultReporterFactory.h
+
+
+#include <memory>
+
+namespace ApprovalTests
+{
+    //! Implementation detail of Approvals::useAsDefaultReporter()
+    class DefaultReporterFactory
+    {
+    private:
+        static std::shared_ptr<Reporter>& defaultReporter();
+
+    public:
+        static std::shared_ptr<Reporter> getDefaultReporter();
+
+        static void setDefaultReporter(const std::shared_ptr<Reporter>& reporter);
+    };
+}
+
+// ******************** From: DefaultReporterDisposer.h
+
+
+namespace ApprovalTests
+{
+    //! Implementation detail of Approvals::useAsDefaultReporter()
+    class APPROVAL_TESTS_NO_DISCARD DefaultReporterDisposer
+    {
+    private:
+        std::shared_ptr<Reporter> previous_result;
+
+    public:
+        explicit DefaultReporterDisposer(const std::shared_ptr<Reporter>& reporter);
+
+        ~DefaultReporterDisposer();
+    };
+}
+
+// ******************** From: FirstWorkingReporter.h
+
+#include <memory>
+#include <vector>
+
+namespace ApprovalTests
+{
+    class FirstWorkingReporter : public Reporter
+    {
+    private:
+        std::vector<std::shared_ptr<Reporter>> reporters;
+
+    public:
+        // Note that FirstWorkingReporter takes ownership of the given Reporter objects
+        explicit FirstWorkingReporter(const std::vector<Reporter*>& theReporters);
+
+        explicit FirstWorkingReporter(
+            const std::vector<std::shared_ptr<Reporter>>& reporters_);
+
+        bool report(std::string received, std::string approved) const override;
+    };
+}
+
+// ******************** From: DefaultFrontLoadedReporter.h
+
+
+namespace ApprovalTests
+{
+    class DefaultFrontLoadedReporter : public FirstWorkingReporter
+    {
+    public:
+        DefaultFrontLoadedReporter();
+    };
+}
+
+// ******************** From: FrontLoadedReporterFactory.h
+
+
+#include <memory>
+
+namespace ApprovalTests
+{
+    //! Implementation detail of Approvals::useAsFrontLoadedReporter()
+    class FrontLoadedReporterFactory
+    {
+        static std::shared_ptr<Reporter>& frontLoadedReporter();
+
+    public:
+        static std::shared_ptr<Reporter> getFrontLoadedReporter();
+
+        static void setFrontLoadedReporter(const std::shared_ptr<Reporter>& reporter);
+    };
+}
+
+// ******************** From: FrontLoadedReporterDisposer.h
+
+
+namespace ApprovalTests
+{
+    //! Implementation detail of Approvals::useAsFrontLoadedReporter()
+    class APPROVAL_TESTS_NO_DISCARD FrontLoadedReporterDisposer
+    {
+    private:
+        std::shared_ptr<Reporter> previous_result;
+
+    public:
+        explicit FrontLoadedReporterDisposer(const std::shared_ptr<Reporter>& reporter);
+        FrontLoadedReporterDisposer(const FrontLoadedReporterDisposer&) = default;
+
+        ~FrontLoadedReporterDisposer();
+    };
+}
+
+// ******************** From: Scrubbers.h
+
+#include <string>
+#include <functional>
+#include <regex>
+
+namespace ApprovalTests
+{
+    using Scrubber = std::function<std::string(const std::string&)>;
+    namespace Scrubbers
+    {
+        std::string doNothing(const std::string& input);
+
+        /**@name Regex-based scrubbers
+
+         See \userguide{how_tos/ScrubNonDeterministicOutput,regular-expressions-regex,Regular Expressions (regex)}
+         */
+        ///@{
+        using RegexMatch = std::sub_match<std::string::const_iterator>;
+        using RegexReplacer = std::function<std::string(const RegexMatch&)>;
+
+        std::string scrubRegex(const std::string& input,
+                               const std::regex& regex,
+                               const RegexReplacer& replaceFunction);
+
+        Scrubber createRegexScrubber(const std::regex& regexPattern,
+                                     const RegexReplacer& replacer);
+
+        Scrubber createRegexScrubber(const std::regex& regexPattern,
+                                     const std::string& replacementText);
+
+        Scrubber createRegexScrubber(const std::string& regexString,
+                                     const std::string& replacementText);
+        ///@}
+
+        std::string scrubGuid(const std::string& input);
+    }
+}
+
+// ******************** From: DefaultNamerFactory.h
+
+
+#include <memory>
+#include <functional>
+
+namespace ApprovalTests
+{
+
+    using NamerCreator = std::function<std::shared_ptr<ApprovalNamer>()>;
+
+    //! Implementation detail of Approvals::useAsDefaultNamer()
+    class DefaultNamerFactory
+    {
+    private:
+        static NamerCreator& defaultNamer();
+
+    public:
+        static NamerCreator getDefaultNamer();
+
+        static void setDefaultNamer(NamerCreator namer);
+    };
+}
+
+// ******************** From: Options.h
+
+#include <utility>
+#include <exception>
+
+
+namespace ApprovalTests
+{
+    class Options
+    {
+    public:
+        class FileOptions
+        {
+            const Options* options_ = nullptr; // set in Options::fileOptions()
+            std::string fileExtensionWithDot_ = ".txt";
+            friend class Options;
+
+            FileOptions() = default;
+
+            explicit FileOptions(std::string fileExtensionWithDot);
+
+            APPROVAL_TESTS_NO_DISCARD
+            FileOptions clone() const;
+
+        public:
+            APPROVAL_TESTS_NO_DISCARD
+            const std::string& getFileExtension() const;
+
+            APPROVAL_TESTS_NO_DISCARD
+            Options withFileExtension(const std::string& fileExtensionWithDot) const;
         };
-        container->push_back( exactNameMatching );
+
+    private:
+        FileOptions fileOptions_;
+        Scrubber scrubber_ = Scrubbers::doNothing;
+        const Reporter& reporter_ = defaultReporter();
+        std::shared_ptr<ApprovalNamer> namer_ = DefaultNamerFactory::getDefaultNamer()();
+        bool usingDefaultScrubber_ = true;
+
+        Options(FileOptions fileOptions,
+                Scrubber scrubber,
+                const Reporter& reporter,
+                bool usingDefaultScrubber,
+                std::shared_ptr<ApprovalNamer> namer);
+
+        APPROVAL_TESTS_NO_DISCARD
+        Options clone(const FileOptions& fileOptions) const;
+
+        static const Reporter& defaultReporter();
+
+    public:
+        Options() = default;
+
+        explicit Options(Scrubber scrubber);
+
+        explicit Options(const Reporter& reporter);
+
+        APPROVAL_TESTS_NO_DISCARD
+        FileOptions fileOptions() const;
+
+        APPROVAL_TESTS_NO_DISCARD
+        Scrubber getScrubber() const;
+
+        APPROVAL_TESTS_NO_DISCARD
+        bool isUsingDefaultScrubber() const;
+
+        APPROVAL_TESTS_NO_DISCARD
+        std::string scrub(const std::string& input) const;
+
+        APPROVAL_TESTS_NO_DISCARD
+        const Reporter& getReporter() const;
+
+        APPROVAL_TESTS_NO_DISCARD
+        Options withReporter(const Reporter& reporter) const;
+
+        APPROVAL_TESTS_NO_DISCARD
+        Options withScrubber(Scrubber scrubber) const;
+
+        APPROVAL_TESTS_NO_DISCARD
+        std::shared_ptr<ApprovalNamer> getNamer() const;
+
+        APPROVAL_TESTS_NO_DISCARD
+        Options withNamer(std::shared_ptr<ApprovalNamer> namer);
+    };
+
+    namespace Detail
+    {
+        //! Helper to prevent compilation failure when types are wrongly treated as Option
+        //  or Reporter:
+        template <typename T, typename R = void>
+        using EnableIfNotOptionsOrReporter = typename std::enable_if<
+            (!std::is_same<Options, typename std::decay<T>::type>::value) &&
+                (!std::is_base_of<Reporter, typename std::decay<T>::type>::value),
+            R>::type;
+
+        //! Helper to prevent compilation failure when types are wrongly treated as Option,
+        //  Reporter or String:
+        template <typename T, typename R = void>
+        using EnableIfNotOptionsOrReporterOrString = typename std::enable_if<
+            (!std::is_same<Options, typename std::decay<T>::type>::value) &&
+                (!std::is_same<std::string, typename std::decay<T>::type>::value) &&
+                (!std::is_same<char*, typename std::decay<T>::type>::value) &&
+                (!std::is_same<const char*, typename std::decay<T>::type>::value) &&
+                (!std::is_base_of<Reporter, typename std::decay<T>::type>::value),
+            R>::type;
+    } // namespace Detail
+}
+
+// ******************** From: ExistingFileNamer.h
+
+#include <utility>
+
+namespace ApprovalTests
+{
+    class ExistingFileNamer : public ApprovalNamer
+    {
+        std::string filePath;
+        const Options& options_;
+
+    public:
+        explicit ExistingFileNamer(std::string filePath_, const Options& options);
+
+        ExistingFileNamer(const ExistingFileNamer& x);
+
+        ExistingFileNamer(ExistingFileNamer&& x) noexcept;
+
+        virtual std::string getApprovedFile(std::string extensionWithDot) const override;
+
+        virtual std::string
+            getReceivedFile(std::string /*extensionWithDot*/) const override;
+    };
+}
+
+// ******************** From: ExistingFile.h
+
+#include <utility>
+
+namespace ApprovalTests
+{
+    class ExistingFile : public ApprovalWriter
+    {
+        std::string filePath;
+        bool deleteScrubbedFile = false;
+        const Options& options_;
+
+        std::string scrub(std::string fileName, const Options& options);
+
+    public:
+        explicit ExistingFile(std::string filePath_, const Options& options);
+        virtual std::string getFileExtensionWithDot() const override;
+        virtual void write(std::string /*path*/) const override;
+        virtual void cleanUpReceived(std::string receivedPath) const override;
+        ExistingFileNamer getNamer();
+    };
+}
+
+// ******************** From: DefaultNamerDisposer.h
+
+
+namespace ApprovalTests
+{
+    //! Implementation detail of Approvals::useAsDefaultNamer()
+    class APPROVAL_TESTS_NO_DISCARD DefaultNamerDisposer
+    {
+    private:
+        NamerCreator previous_result;
+
+    public:
+        explicit DefaultNamerDisposer(NamerCreator namerCreator);
+        DefaultNamerDisposer(const DefaultNamerDisposer&) = default;
+
+        ~DefaultNamerDisposer();
+    };
+}
+
+// ******************** From: Approvals.h
+#include <string>
+#include <functional>
+#include <exception>
+#include <utility>
+
+
+namespace ApprovalTests
+{
+
+    // TCompileTimeOptions must have a type ToStringConverter, which must have a method toString()
+    template <typename TCompileTimeOptions> class TApprovals
+    {
+    private:
+        TApprovals() = default;
+
+        ~TApprovals() = default;
+
+    public:
+        static std::shared_ptr<ApprovalNamer> getDefaultNamer()
+        {
+            return DefaultNamerFactory::getDefaultNamer()();
+        }
+
+        template <typename T>
+        using IsNotDerivedFromWriter =
+            typename std::enable_if<!std::is_base_of<ApprovalWriter, T>::value,
+                                    int>::type;
+
+        /**@name Verifying single objects
+
+         See \userguide{TestingSingleObjects,Testing Single Objects}
+         */
+        ///@{
+        static void verify(const std::string& contents,
+                           const Options& options = Options())
+        {
+            StringWriter writer(options.scrub(contents),
+                                options.fileOptions().getFileExtension());
+            FileApprover::verify(*options.getNamer(), writer, options.getReporter());
+        }
+
+        template <typename T, typename = IsNotDerivedFromWriter<T>>
+        static void verify(const T& contents, const Options& options = Options())
+        {
+            verify(TCompileTimeOptions::ToStringConverter::toString(contents), options);
+        }
+
+        template <typename T,
+                  typename Function,
+                  typename = Detail::EnableIfNotOptionsOrReporter<Function>>
+        static void
+        verify(const T& contents, Function converter, const Options& options = Options())
+        {
+            std::stringstream s;
+            converter(contents, s);
+            verify(s.str(), options);
+        }
+
+        /// Note that this overload ignores any scrubber in options
+        static void verify(const ApprovalWriter& writer,
+                           const Options& options = Options())
+        {
+            FileApprover::verify(*options.getNamer(), writer, options.getReporter());
+        }
+        ///@}
+
+        /**@name Verifying containers of objects - supplying an iterator range
+
+         See \userguide{TestingContainers,Testing Containers}
+         */
+        ///@{
+        template <typename Iterator>
+        static void
+        verifyAll(const std::string& header,
+                  const Iterator& start,
+                  const Iterator& finish,
+                  std::function<void(decltype(*start), std::ostream&)> converter,
+                  const Options& options = Options())
+        {
+            std::stringstream s;
+            ApprovalUtils::writeHeader(s, header);
+            for (auto it = start; it != finish; ++it)
+            {
+                converter(*it, s);
+                s << '\n';
+            }
+            verify(s.str(), options);
+        }
+        ///@}
+
+        /**@name Verifying containers of objects - supplying a container
+
+         See \userguide{TestingContainers,Testing Containers}
+         */
+        ///@{
+        template <typename Container>
+        static void verifyAll(
+            const std::string& header,
+            const Container& list,
+            std::function<void(typename Container::value_type, std::ostream&)> converter,
+            const Options& options = Options())
+        {
+            verifyAll<typename Container::const_iterator>(
+                header, list.begin(), list.end(), converter, options);
+        }
+
+        template <typename Container>
+        static void verifyAll(const std::string& header,
+                              const Container& list,
+                              const Options& options = Options())
+        {
+            int i = 0;
+            verifyAll<Container>(
+                header,
+                list,
+                [&](typename Container::value_type e, std::ostream& s) {
+                    s << "[" << i++
+                      << "] = " << TCompileTimeOptions::ToStringConverter::toString(e);
+                },
+                options);
+        }
+
+        template <typename Container>
+        static void verifyAll(const Container& list, const Options& options = Options())
+        {
+            verifyAll<Container>("", list, options);
+        }
+        ///@}
+
+        /**@name Verifying containers of objects - supplying an initializer list
+
+         See \userguide{TestingContainers,Testing Containers}
+         */
+        ///@{
+        template <typename T>
+        static void
+        verifyAll(const std::string& header,
+                  const std::initializer_list<T>& list,
+                  std::function<void(typename std::initializer_list<T>::value_type,
+                                     std::ostream&)> converter,
+                  const Options& options = Options())
+        {
+            verifyAll<std::initializer_list<T>>(header, list, converter, options);
+        }
+
+        template <typename T>
+        static void verifyAll(const std::string& header,
+                              const std::initializer_list<T>& list,
+                              const Options& options = Options())
+        {
+            verifyAll<std::initializer_list<T>>(header, list, options);
+        }
+
+        template <typename T>
+        static void verifyAll(const std::initializer_list<T>& list,
+                              const Options& options = Options())
+        {
+            verifyAll<std::initializer_list<T>>("", list, options);
+        }
+        ///@}
+
+        /**@name Other verify methods
+         */
+        ///@{
+
+        /*! \brief Verify the text of an exception
+
+            See \userguide{TestingExceptions,testing-exception-messages,Testing exception messages}
+         */
+        static void
+        verifyExceptionMessage(const std::function<void(void)>& functionThatThrows,
+                               const Options& options = Options())
+        {
+            std::string message = "*** no exception thrown ***";
+            try
+            {
+                functionThatThrows();
+            }
+            catch (const std::exception& e)
+            {
+                message = e.what();
+            }
+            verify(message, options);
+        }
+
+        /// Verify an existing file, that has already been written out
+        static void verifyExistingFile(const std::string& filePath,
+                                       const Options& options = Options())
+        {
+            ExistingFile writer(filePath, options);
+            FileApprover::verify(writer.getNamer(), writer, options.getReporter());
+        }
+        ///@}
+
+        /**@name Customising Approval Tests
+
+         These static methods customise various aspects
+         of Approval Tests behaviour.
+         */
+        ///@{
+
+        /// See \userguide{Configuration,using-sub-directories-for-approved-files,Using sub-directories for approved files}
+        static SubdirectoryDisposer
+        useApprovalsSubdirectory(const std::string& subdirectory = "approval_tests")
+        {
+            return SubdirectoryDisposer(subdirectory);
+        }
+
+        /// See \userguide{Reporters,registering-a-default-reporter,Registering a default reporter}
+        static DefaultReporterDisposer
+        useAsDefaultReporter(const std::shared_ptr<Reporter>& reporter)
+        {
+            return DefaultReporterDisposer(reporter);
+        }
+
+        /// See \userguide{Reporters,front-loaded-reporters,Front Loaded Reporters}
+        static FrontLoadedReporterDisposer
+        useAsFrontLoadedReporter(const std::shared_ptr<Reporter>& reporter)
+        {
+            return FrontLoadedReporterDisposer(reporter);
+        }
+
+        /// See \userguide{Namers,registering-a-custom-namer,Registering a Custom Namer}
+        static DefaultNamerDisposer useAsDefaultNamer(NamerCreator namerCreator)
+        {
+            return DefaultNamerDisposer(std::move(namerCreator));
+        }
+
+        /// See \userguide{Namers,converting-test-names-to-valid-filenames,Converting Test Names to Valid FileNames}
+        static FileNameSanitizerDisposer useFileNameSanitizer(FileNameSanitizer sanitizer)
+        {
+            return FileNameSanitizerDisposer(sanitizer);
+        }
+        ///@}
+    };
+
+#ifndef APPROVAL_TESTS_DEFAULT_STREAM_CONVERTER
+#define APPROVAL_TESTS_DEFAULT_STREAM_CONVERTER StringMaker
+#endif
+
+    // Warning: Do not use CompileTimeOptions directly.
+    // This interface is subject to change, as future
+    // compile-time options are added.
+    template <typename TToString> struct CompileTimeOptions
+    {
+        using ToStringConverter = TToString;
+        // more template types may be added to CompileTimeOptions in future, if we add
+        // more flexibility that requires compile-time configuration.
+    };
+
+    // Template parameter TToString must have a method toString()
+    // This interface will not change, as future compile-time options are added.
+    template <typename TToString>
+    struct ToStringCompileTimeOptions : CompileTimeOptions<TToString>
+    {
+    };
+
+    using Approvals =
+        TApprovals<ToStringCompileTimeOptions<APPROVAL_TESTS_DEFAULT_STREAM_CONVERTER>>;
+}
+
+// ******************** From: TemplatedCustomNamer.h
+
+
+namespace ApprovalTests
+{
+    class TemplatedCustomNamer : public ApprovalTests::ApprovalNamer
+    {
+    private:
+        ApprovalTests::ApprovalTestNamer namer_;
+        std::string template_;
+
+    public:
+        explicit TemplatedCustomNamer(std::string templateString);
+
+        APPROVAL_TESTS_NO_DISCARD
+        Path constructFromTemplate(const std::string& extensionWithDot,
+                                   const std::string& approvedOrReceived) const;
+
+        APPROVAL_TESTS_NO_DISCARD
+        std::string getApprovedFile(std::string extensionWithDot) const override;
+
+        APPROVAL_TESTS_NO_DISCARD
+        std::string getReceivedFile(std::string extensionWithDot) const override;
+
+        APPROVAL_TESTS_NO_DISCARD
+        Path getApprovedFileAsPath(std::string extensionWithDot) const;
+
+        APPROVAL_TESTS_NO_DISCARD
+        Path getReceivedFileAsPath(std::string extensionWithDot) const;
+
+        APPROVAL_TESTS_NO_DISCARD
+        static std::shared_ptr<TemplatedCustomNamer> create(std::string templateString);
+
+        APPROVAL_TESTS_NO_DISCARD
+        static DefaultNamerDisposer useAsDefaultNamer(std::string templateString);
+    };
+}
+
+// ******************** From: GoogleCustomizationsFactory.h
+
+
+#include <vector>
+#include <functional>
+#include <string>
+
+namespace ApprovalTests
+{
+    class GoogleCustomizationsFactory
+    {
+    public:
+        using Comparator = std::function<bool(const std::string&, const std::string&)>;
+
+    private:
+        using ComparatorContainer = std::vector<Comparator>;
+        static ComparatorContainer& comparatorContainer();
+
+    public:
+        static ComparatorContainer getEquivalencyChecks();
+
+        APPROVAL_TESTS_NO_DISCARD static bool
+        addTestCaseNameRedundancyCheck(const Comparator& comparator);
+    };
+}
+
+// ******************** From: MoreHelpMessages.h
+
+#include <string>
+
+namespace ApprovalTests
+{
+    class MoreHelpMessages
+    {
+    public:
+        static void deprecatedFunctionCalled(const std::string& message,
+                                             const std::string& file,
+                                             int lineNumber);
+    };
+}
+
+// ******************** From: CartesianProduct.h
+
+#include <functional>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace ApprovalTests
+{
+    namespace CartesianProduct
+    {
+        namespace Detail
+        {
+
+            // C++14 compatibility
+            // See https://en.cppreference.com/w/cpp/types/enable_if
+            template <bool B, class T = void>
+            using enable_if_t = typename std::enable_if<B, T>::type;
+
+            // See https://en.cppreference.com/w/cpp/utility/integer_sequence
+            template <std::size_t... Is> struct index_sequence
+            {
+            };
+
+            template <std::size_t N, std::size_t... Is>
+            struct make_index_sequence : make_index_sequence<N - 1, N - 1, Is...>
+            {
+            };
+
+            template <std::size_t... Is>
+            struct make_index_sequence<0, Is...> : index_sequence<Is...>
+            {
+            };
+            // End of C++14 compatibility
+
+            // Return the size of a tuple - constexpr for use as a template argument
+            // See https://en.cppreference.com/w/cpp/utility/tuple/tuple_size
+            template <class Tuple> constexpr std::size_t tuple_size()
+            {
+                return std::tuple_size<
+                    typename std::remove_reference<Tuple>::type>::value;
+            }
+
+            template <class Tuple>
+            using make_tuple_idxs = make_index_sequence<tuple_size<Tuple>()>;
+
+            // C++17 compatibility
+            // See https://en.cppreference.com/w/cpp/utility/apply
+            template <class F, class Tuple, std::size_t... I>
+            constexpr auto apply_impl(F&& f, Tuple&& t, index_sequence<I...>)
+                -> decltype(std::forward<F>(f)(std::get<I>(std::forward<Tuple>(t))...))
+            {
+                return std::forward<F>(f)(std::get<I>(std::forward<Tuple>(t))...);
+            }
+
+            template <class F, class Tuple>
+            auto apply(F&& f, Tuple&& t) -> decltype(apply_impl(std::forward<F>(f),
+                                                                std::forward<Tuple>(t),
+                                                                make_tuple_idxs<Tuple>{}))
+            {
+                return apply_impl(
+                    std::forward<F>(f), std::forward<Tuple>(t), make_tuple_idxs<Tuple>{});
+            }
+            // End of C++17 compatibility
+
+            template <class Tuple, class F, std::size_t... Is>
+            void for_each_impl(Tuple&& t, F&& f, index_sequence<Is...>)
+            {
+                (void)std::initializer_list<int>{
+                    (std::forward<F>(f)(std::get<Is>(std::forward<Tuple>(t))), 0)...};
+            }
+
+            template <class Tuple, class F> void for_each(Tuple&& t, F&& f)
+            {
+                for_each_impl(
+                    std::forward<Tuple>(t), std::forward<F>(f), make_tuple_idxs<Tuple>{});
+            }
+
+            template <class Tuple, class F, std::size_t... Is>
+            auto transform_impl(Tuple&& t, F&& f, index_sequence<Is...>)
+                -> decltype(std::make_tuple(
+                    std::forward<F>(f)(std::get<Is>(std::forward<Tuple>(t)))...))
+            {
+                return std::make_tuple(
+                    std::forward<F>(f)(std::get<Is>(std::forward<Tuple>(t)))...);
+            }
+
+            template <class F, class Tuple>
+            auto transform(Tuple&& t, F&& f = {})
+                -> decltype(transform_impl(std::forward<Tuple>(t),
+                                           std::forward<F>(f),
+                                           make_tuple_idxs<Tuple>{}))
+            {
+                return transform_impl(
+                    std::forward<Tuple>(t), std::forward<F>(f), make_tuple_idxs<Tuple>{});
+            }
+
+            template <class Predicate> struct find_if_body
+            {
+                const Predicate& pred;
+                std::size_t& index;
+                std::size_t currentIndex = 0;
+                bool found = false;
+
+                find_if_body(const Predicate& p, std::size_t& i) : pred(p), index(i)
+                {
+                }
+
+                template <typename T> void operator()(T&& value)
+                {
+                    if (found)
+                        return;
+                    if (pred(std::forward<T>(value)))
+                    {
+                        index = currentIndex;
+                        found = true;
+                    }
+                    ++currentIndex;
+                }
+            };
+
+            template <class Predicate, class Tuple>
+            std::size_t find_if(Tuple&& tuple, Predicate pred = {})
+            {
+                std::size_t idx = tuple_size<Tuple>();
+                for_each(std::forward<Tuple>(tuple), find_if_body<Predicate>(pred, idx));
+                return idx;
+            }
+
+            template <class Predicate, class Tuple>
+            bool any_of(Tuple&& tuple, Predicate pred = {})
+            {
+                return find_if(std::forward<Tuple>(tuple), pred) != tuple_size<Tuple>();
+            }
+
+            struct is_range_empty
+            {
+                template <class T> bool operator()(const T& range) const
+                {
+                    using std::begin;
+                    using std::end;
+                    return begin(range) == end(range);
+                }
+            };
+
+            // Transform an iterator into a value reference which will then be passed to the visitor function:
+            struct dereference_iterator
+            {
+                template <class It>
+                auto operator()(It&& it) const -> decltype(*std::forward<It>(it))
+                {
+                    return *std::forward<It>(it);
+                }
+            };
+
+            // Increment outermost iterator. If it reaches its end, we're finished and do nothing.
+            template <class Its, std::size_t I = tuple_size<Its>() - 1>
+            enable_if_t<I == 0> increment_iterator(Its& it, const Its&, const Its&)
+            {
+                ++std::get<I>(it);
+            }
+
+            // Increment inner iterator. If it reaches its end, we reset it and increment the previous iterator.
+            template <class Its, std::size_t I = tuple_size<Its>() - 1>
+            enable_if_t<I != 0>
+            increment_iterator(Its& its, const Its& begins, const Its& ends)
+            {
+                if (++std::get<I>(its) == std::get<I>(ends))
+                {
+                    std::get<I>(its) = std::get<I>(begins);
+                    increment_iterator<Its, I - 1>(its, begins, ends);
+                }
+            }
+        } // namespace Detail
+
+        // This is what actually loops over all the containers, one element at a time
+        // It is called with a template type F that writes the inputs, and runs the converter, which writes the result(s)
+        // all for one set of container values - when called by verifyAllCombinations()
+        // More generally, F must have an operator() that acts on one set of input values.
+        template <class F, class... Ranges>
+        void cartesian_product(F&& f, const Ranges&... ranges)
+        {
+            using std::begin;
+            using std::end;
+
+            if (Detail::any_of<Detail::is_range_empty>(std::forward_as_tuple(ranges...)))
+                return;
+
+            const auto begins = std::make_tuple(begin(ranges)...);
+            const auto ends = std::make_tuple(end(ranges)...);
+
+            for (auto its = begins; std::get<0>(its) != std::get<0>(ends);
+                 Detail::increment_iterator(its, begins, ends))
+            {
+                // Command-clicking on transform in CLion 2019.2.1 hangs with CLion with high CPU
+                // 'Use clang tidy' is turned off.
+                // Power-save turned on.
+                // Mac
+                Detail::apply(std::forward<F>(f),
+                              Detail::transform<Detail::dereference_iterator>(its));
+            }
+        }
+    } // namespace CartesianProduct
+} // namespace ApprovalTests
+
+// ******************** From: DefaultReporter.h
+
+
+#include <string>
+
+namespace ApprovalTests
+{
+    class DefaultReporter : public Reporter
+    {
+    public:
+        virtual bool report(std::string received, std::string approved) const override;
+    };
+}
+
+// ******************** From: CombinationApprovals.h
+
+#include <type_traits>
+#include <utility>
+
+namespace ApprovalTests
+{
+    template <typename TCompileTimeOptions> class TCombinationApprovals
+    {
+    private:
+        // Write out second or subsequent input value, with preceding comma and space
+        struct print_input
+        {
+            std::ostream& out;
+            template <class T> void operator()(const T& input)
+            {
+                out << ", " << TCompileTimeOptions::ToStringConverter::toString(input);
+            }
+        };
+
+        // Write out one row of output
+        template <class Converter> struct serialize
+        {
+            std::ostream& out;
+            Converter converter;
+            template <class T, class... Ts> void operator()(T&& input1_, Ts&&... inputs)
+            {
+                // First value is printed without trailing comma
+                out << "(" << TCompileTimeOptions::ToStringConverter::toString(input1_);
+                // Remaining values are printed with prefix of a comma
+                CartesianProduct::Detail::for_each(std::forward_as_tuple(inputs...),
+                                                   print_input{out});
+                out << ") => " << converter(input1_, inputs...) << '\n';
+            }
+        };
+
+    public:
+        /**@name Verifying combinations of objects
+
+         See \userguide{TestingCombinations,Testing combinations}
+         */
+        ///@{
+        template <class Converter, class Container, class... Containers>
+        static void verifyAllCombinations(const Options& options,
+                                          const std::string& header,
+                                          Converter&& converter,
+                                          const Container& input0,
+                                          const Containers&... inputs)
+        {
+            std::stringstream s;
+            ApprovalUtils::writeHeader(s, header);
+            CartesianProduct::cartesian_product(
+                serialize<Converter>{s, std::forward<Converter>(converter)},
+                input0,
+                inputs...);
+            Approvals::verify(s.str(), options);
+        }
+
+        template <class Converter, class... Containers>
+        ApprovalTests::Detail::EnableIfNotOptionsOrReporterOrString<
+            Converter> static verifyAllCombinations(const std::string& header,
+                                                    Converter&& converter,
+                                                    const Containers&... inputs)
+        {
+            verifyAllCombinations(
+                Options(), header, std::forward<Converter>(converter), inputs...);
+        }
+
+        template <class Converter, class... Containers>
+        ApprovalTests::Detail::EnableIfNotOptionsOrReporterOrString<
+            Converter> static verifyAllCombinations(const Options& options,
+                                                    Converter&& converter,
+                                                    const Containers&... inputs)
+        {
+            verifyAllCombinations(
+                options, std::string(), std::forward<Converter>(converter), inputs...);
+        }
+
+        template <class Converter, class... Containers>
+        ApprovalTests::Detail::EnableIfNotOptionsOrReporterOrString<
+            Converter> static verifyAllCombinations(Converter&& converter,
+                                                    const Containers&... inputs)
+        {
+            verifyAllCombinations(
+                Options(), std::string(), std::forward<Converter>(converter), inputs...);
+        }
+        ///@}
+    };
+
+    using CombinationApprovals = TCombinationApprovals<
+        ToStringCompileTimeOptions<APPROVAL_TESTS_DEFAULT_STREAM_CONVERTER>>;
+
+} // namespace ApprovalTests
+
+// ******************** From: Storyboard.h
+
+#include <iosfwd>
+#include <sstream>
+#include <functional>
+
+namespace ApprovalTests
+{
+    class Storyboard
+    {
+    private:
+        std::stringstream output_;
+        int frameCount_ = 0;
+        bool addNewLineBeforeNextFrame_ = false;
+
+    public:
+        Storyboard& addDescription(const std::string& description);
+
+        Storyboard& addDescriptionWithData(const std::string& description,
+                                           const std::string& data);
+
+        Storyboard& addFrame(const std::string& frame);
+
+        Storyboard& addFrame(const std::string& title, const std::string& frame);
+
+        Storyboard& addFrames(int numberOfFrames,
+                              const std::function<std::string(int)>& function);
+
+        friend std::ostream& operator<<(std::ostream& os, const Storyboard& board);
+    };
+}
+
+// ******************** From: TextFileComparator.h
+
+
+#include <fstream>
+
+namespace ApprovalTests
+{
+    class TextFileComparator : public ApprovalComparator
+    {
+    public:
+        static std::ifstream::int_type getNextRelevantCharacter(std::ifstream& astream);
+
+        virtual bool contentsAreEquivalent(std::string receivedPath,
+                                           std::string approvedPath) const override;
+    };
+}
+
+// ******************** From: ApprovalException.h
+
+#include <exception>
+#include <string>
+
+namespace ApprovalTests
+{
+    class ApprovalException : public std::exception
+    {
+    private:
+        std::string message;
+
+    public:
+        explicit ApprovalException(const std::string& msg);
+
+        virtual const char* what() const noexcept override;
+    };
+
+    class ApprovalMismatchException : public ApprovalException
+    {
+    private:
+        std::string format(const std::string& received, const std::string& approved);
+
+    public:
+        ApprovalMismatchException(const std::string& received,
+                                  const std::string& approved);
+    };
+
+    class ApprovalMissingException : public ApprovalException
+    {
+    private:
+        std::string format(const std::string& file);
+
+    public:
+        ApprovalMissingException(const std::string& /*received*/,
+                                 const std::string& approved);
+    };
+}
+
+// ******************** From: FrameworkIntegrations.h
+
+
+namespace ApprovalTests
+{
+    class FrameworkIntegrations
+    {
+    public:
+        static void
+        setTestPassedNotification(FileApprover::TestPassedNotification notification);
+
+        static void setCurrentTest(ApprovalTests::TestName* currentTest);
+    };
+}
+
+// ******************** From: BoostTestApprovals.h
+
+
+#ifdef APPROVALS_BOOSTTEST
+#define APPROVAL_TESTS_INCLUDE_CPPS
+
+namespace ApprovalTests
+{
+
+    class BoostApprovalListener : public boost::unit_test::test_observer
+    {
+        ApprovalTests::TestName currentTest;
+
+        void test_unit_start(boost::unit_test::test_unit const& test) override
+        {
+            std::string path(test.p_file_name.begin(), test.p_file_name.end());
+            currentTest.setFileName(path);
+
+            currentTest.sections.push_back(test.p_name);
+            ApprovalTests::FrameworkIntegrations::setCurrentTest(&currentTest);
+            ApprovalTests::FrameworkIntegrations::setTestPassedNotification(
+                []() { BOOST_CHECK(true); });
+        }
+
+        void test_unit_finish(boost::unit_test::test_unit const& /*test*/,
+                              unsigned long) override
+        {
+            currentTest.sections.pop_back();
+        }
+    };
+
+    int register_our_listener(BoostApprovalListener& t)
+    {
+        boost::unit_test::framework::register_observer(t);
+        return 1;
+    }
+
+    BoostApprovalListener o;
+    auto dummy_variable = register_our_listener(o);
+}
+
+#endif // APPROVALS_BOOSTTEST
+
+// ******************** From: Catch2Approvals.h
+
+
+
+#if defined(APPROVALS_CATCH_EXISTING_MAIN)
+#define APPROVALS_CATCH
+#define CATCH_CONFIG_RUNNER
+#elif defined(APPROVALS_CATCH)
+#define CATCH_CONFIG_MAIN
+#endif
+
+#ifdef APPROVALS_CATCH
+#define APPROVAL_TESTS_INCLUDE_CPPS
+
+#include <catch2/catch.hpp>
+
+//namespace ApprovalTests {
+struct Catch2ApprovalListener : Catch::TestEventListenerBase
+{
+    ApprovalTests::TestName currentTest;
+    using TestEventListenerBase::
+        TestEventListenerBase; // This using allows us to use all base-class constructors
+    virtual void testCaseStarting(Catch::TestCaseInfo const& testInfo) override
+    {
+
+        currentTest.setFileName(testInfo.lineInfo.file);
+        ApprovalTests::FrameworkIntegrations::setCurrentTest(&currentTest);
+        ApprovalTests::FrameworkIntegrations::setTestPassedNotification(
+            []() { REQUIRE(true); });
+    }
+
+    virtual void testCaseEnded(Catch::TestCaseStats const& /*testCaseStats*/) override
+    {
+        while (!currentTest.sections.empty())
+        {
+            currentTest.sections.pop_back();
+        }
+    }
+
+    virtual void sectionStarting(Catch::SectionInfo const& sectionInfo) override
+    {
+        currentTest.sections.push_back(sectionInfo.name);
+    }
+
+    virtual void sectionEnded(Catch::SectionStats const& /*sectionStats*/) override
+    {
+        currentTest.sections.pop_back();
+    }
+};
+//}
+CATCH_REGISTER_LISTENER(Catch2ApprovalListener)
+
+#endif
+#ifdef TEST_COMMIT_REVERT_CATCH
+
+//namespace ApprovalTests {
+struct Catch2TestCommitRevert : Catch::TestEventListenerBase
+{
+    using TestEventListenerBase::
+        TestEventListenerBase; // This using allows us to use all base-class constructors
+    virtual void testRunEnded(Catch::TestRunStats const& testRunStats) override
+    {
+        bool commit = testRunStats.totals.testCases.allOk();
+        std::string message = "r ";
+        if (commit)
+        {
+            std::cout << "git add -A \n";
+            std::cout << "git commit -m " << message;
+        }
+        else
+        {
+            std::cout << "git clean -fd \n";
+            std::cout << "git reset --hard HEAD \n";
+        }
+    }
+};
+//}
+CATCH_REGISTER_LISTENER(Catch2TestCommitRevert)
+#endif
+
+// ******************** From: CppUTestApprovals.h
+
+
+#ifdef APPROVALS_CPPUTEST_EXISTING_MAIN
+#define APPROVALS_CPPUTEST
+#endif
+
+#ifdef APPROVALS_CPPUTEST
+#define APPROVAL_TESTS_INCLUDE_CPPS
+
+#include <CppUTest/CommandLineTestRunner.h>
+#include <CppUTest/TestPlugin.h>
+#include <CppUTest/TestRegistry.h>
+
+namespace ApprovalTests
+{
+    class ApprovalTestsCppUTestPlugin : public TestPlugin
+    {
+    private:
+        // We need to be able to delete currentTest at the end of the
+        // test, to prevent CppUTest's leak-checking from triggering,
+        // due to an undeleted std::string - so we use std::unique_ptr.
+        std::unique_ptr<ApprovalTests::TestName> currentTest;
+
+    public:
+        ApprovalTestsCppUTestPlugin() : TestPlugin("ApprovalTestsCppUTestPlugin")
+        {
+            // Turn off CppUTest's leak checks.
+            // On some platforms, CppUTest's leak-checking reports leaks
+            // in this code, because the way the platform's std::string manages life-times
+            // of string storage is not compatible with the requirements of the
+            // CppUTest leak-checks.
+            MemoryLeakWarningPlugin::turnOffNewDeleteOverloads();
+        }
+
+        APPROVAL_TESTS_NO_DISCARD static std::string
+        cppUTestToString(const SimpleString& string)
+        {
+            return std::string{string.asCharString()};
+        }
+
+        void preTestAction(UtestShell& shell, TestResult& result) override
+        {
+            currentTest.reset(new ApprovalTests::TestName);
+            currentTest->setFileName(cppUTestToString(shell.getFile()));
+
+            currentTest->sections.emplace_back(cppUTestToString(shell.getGroup()));
+            currentTest->sections.emplace_back(cppUTestToString(shell.getName()));
+
+            ApprovalTests::FrameworkIntegrations::setCurrentTest(currentTest.get());
+            ApprovalTests::FrameworkIntegrations::setTestPassedNotification(
+                []() { CHECK_TRUE(true); });
+            TestPlugin::preTestAction(shell, result);
+        }
+
+        void postTestAction(UtestShell& shell, TestResult& result) override
+        {
+            currentTest = nullptr;
+            TestPlugin::postTestAction(shell, result);
+        }
+    };
+
+    inline void initializeApprovalTestsForCppUTest()
+    {
+        static ApprovalTests::ApprovalTestsCppUTestPlugin logPlugin;
+        TestRegistry::getCurrentRegistry()->installPlugin(&logPlugin);
+    }
+}
+
+#ifndef APPROVALS_CPPUTEST_EXISTING_MAIN
+int main(int argc, char** argv)
+{
+    ApprovalTests::initializeApprovalTestsForCppUTest();
+
+    int result = CommandLineTestRunner::RunAllTests(argc, argv);
+    TestRegistry::getCurrentRegistry()->resetPlugins();
+    return result;
+}
+#endif
+
+#endif // APPROVALS_CPPUTEST
+
+// ******************** From: DocTestApprovals.h
+
+
+#if defined(APPROVALS_DOCTEST_EXISTING_MAIN)
+#define APPROVALS_DOCTEST
+#define DOCTEST_CONFIG_IMPLEMENT
+#elif defined(APPROVALS_DOCTEST)
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#endif
+
+#ifdef APPROVALS_DOCTEST
+#define APPROVAL_TESTS_INCLUDE_CPPS
+
+#include <doctest/doctest.h>
+
+namespace ApprovalTests
+{
+    // anonymous namespace to prevent compiler -Wsubobject-linkage warnings
+    // This is OK as this code is only compiled on main()
+    namespace
+    {
+        struct AbstractReporter : doctest::IReporter
+        {
+            virtual void report_query(const doctest::QueryData&) override
+            {
+            }
+            // called when the whole test run starts
+            virtual void test_run_start() override
+            {
+            }
+
+            // called when the whole test run ends (caching a pointer to the input doesn't make sense here)
+            virtual void test_run_end(const doctest::TestRunStats&) override
+            {
+            }
+
+            // called when a test case is started (safe to cache a pointer to the input)
+            virtual void test_case_start(const doctest::TestCaseData&) override
+            {
+            }
+
+#if 20305 <= DOCTEST_VERSION
+            // called when a test case is reentered because of unfinished subcases (safe to cache a pointer to the input)
+            virtual void test_case_reenter(const doctest::TestCaseData&) override
+            {
+            }
+#endif
+
+            // called when a test case has ended
+            virtual void test_case_end(const doctest::CurrentTestCaseStats&) override
+            {
+            }
+
+            // called when an exception is thrown from the test case (or it crashes)
+            virtual void test_case_exception(const doctest::TestCaseException&) override
+            {
+            }
+
+            // called whenever a subcase is entered (don't cache pointers to the input)
+            virtual void subcase_start(const doctest::SubcaseSignature&) override
+            {
+            }
+
+            // called whenever a subcase is exited (don't cache pointers to the input)
+            virtual void subcase_end() override
+            {
+            }
+
+            // called for each assert (don't cache pointers to the input)
+            virtual void log_assert(const doctest::AssertData&) override
+            {
+            }
+
+            // called for each message (don't cache pointers to the input)
+            virtual void log_message(const doctest::MessageData&) override
+            {
+            }
+
+            // called when a test case is skipped either because it doesn't pass the filters, has a skip decorator
+            // or isn't in the execution range (between first and last) (safe to cache a pointer to the input)
+            virtual void test_case_skipped(const doctest::TestCaseData&) override
+            {
+            }
+        };
+
+        struct DocTestApprovalListener : AbstractReporter
+        {
+            TestName currentTest;
+
+            // constructor has to accept the ContextOptions by ref as a single argument
+            explicit DocTestApprovalListener(const doctest::ContextOptions& /*in*/)
+            {
+            }
+
+            std::string doctestToString(const doctest::String& string) const
+            {
+                return string.c_str();
+            }
+
+            std::string doctestToString(const char* string) const
+            {
+                return string;
+            }
+
+            void test_case_start(const doctest::TestCaseData& testInfo) override
+            {
+                currentTest.sections.emplace_back(testInfo.m_name);
+                currentTest.setFileName(doctestToString(testInfo.m_file));
+                ApprovalTests::FrameworkIntegrations::setCurrentTest(&currentTest);
+                ApprovalTests::FrameworkIntegrations::setTestPassedNotification(
+                    []() { REQUIRE(true); });
+            }
+
+            void test_case_end(const doctest::CurrentTestCaseStats& /*in*/) override
+            {
+
+                while (!currentTest.sections.empty())
+                {
+                    currentTest.sections.pop_back();
+                }
+            }
+
+            void subcase_start(const doctest::SubcaseSignature& signature) override
+            {
+                currentTest.sections.emplace_back(doctestToString(signature.m_name));
+            }
+
+            void subcase_end() override
+            {
+
+                currentTest.sections.pop_back();
+            }
+        };
+    }
+}
+
+REGISTER_LISTENER("approvals", 0, ApprovalTests::DocTestApprovalListener);
+
+#endif // APPROVALS_DOCTEST
+
+// ******************** From: FmtApprovals.h
+#ifdef FMT_VERSION
+namespace ApprovalTests
+{
+    using FmtApprovals =
+        ApprovalTests::TApprovals<ApprovalTests::ToStringCompileTimeOptions<FmtToString>>;
+}
+#endif
+
+// ******************** From: GoogleConfiguration.h
+
+
+namespace ApprovalTests
+{
+    class GoogleConfiguration
+    {
+    public:
+        // This result is not used, it is only there to allow the method to execute, when this is used outside a function.
+        APPROVAL_TESTS_NO_DISCARD static bool addTestCaseNameRedundancyCheck(
+            GoogleCustomizationsFactory::Comparator comparator);
+
+        // This result is not used, it is only there to allow the method to execute, when this is used outside a function.
+        APPROVAL_TESTS_NO_DISCARD static bool
+        addIgnorableTestCaseNameSuffix(std::string suffix);
+
+        static GoogleCustomizationsFactory::Comparator
+        createIgnorableTestCaseNameSuffixCheck(const std::string& suffix);
+    };
+}
+
+// ******************** From: GoogleTestApprovals.h
+
+
+#ifdef APPROVALS_GOOGLETEST_EXISTING_MAIN
+#define APPROVALS_GOOGLETEST
+#endif
+
+#ifdef APPROVALS_GOOGLETEST
+#define APPROVAL_TESTS_INCLUDE_CPPS
+
+#include <gtest/gtest.h>
+
+namespace ApprovalTests
+{
+    class GoogleTestListener : public testing::EmptyTestEventListener
+    {
+        TestName currentTest;
+
+    public:
+        bool isDuplicate(std::string testFileNameWithExtension, std::string testCaseName)
+        {
+            for (auto check : GoogleCustomizationsFactory::getEquivalencyChecks())
+            {
+                if (check(testFileNameWithExtension, testCaseName))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        virtual void OnTestStart(const testing::TestInfo& testInfo) override
+        {
+            currentTest.setFileName(testInfo.file());
+            currentTest.sections = {};
+            if (!isDuplicate(currentTest.getFileName(), testInfo.test_case_name()))
+            {
+                currentTest.sections.emplace_back(testInfo.test_case_name());
+            }
+            if (!std::string(testInfo.name()).empty())
+            {
+                currentTest.sections.emplace_back(testInfo.name());
+            }
+
+            ApprovalTests::FrameworkIntegrations::setCurrentTest(&currentTest);
+            ApprovalTests::FrameworkIntegrations::setTestPassedNotification(
+                []() { EXPECT_TRUE(true); });
+        }
+    };
+
+    inline void initializeApprovalTestsForGoogleTests()
+    {
+        auto& listeners = testing::UnitTest::GetInstance()->listeners();
+        listeners.Append(new GoogleTestListener);
+    }
+}
+
+#ifndef APPROVALS_GOOGLETEST_EXISTING_MAIN
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    ApprovalTests::initializeApprovalTestsForGoogleTests();
+    return RUN_ALL_TESTS();
+}
+#endif //APPROVALS_GOOGLETEST_EXISTING_MAIN
+
+#endif
+
+// ******************** From: UTApprovals.h
+
+
+#ifdef APPROVALS_UT
+#define APPROVAL_TESTS_INCLUDE_CPPS
+
+#if !(__GNUC__ >= 9 or __clang_major__ >= 9)
+#error                                                                                   \
+    "The [Boost].UT integration with Approval Tests requires source_location support by the compiler"
+#endif
+
+#include <boost/ut.hpp>
+
+namespace ApprovalTests
+{
+    namespace cfg
+    {
+        void notify_success();
+
+        class reporter : public boost::ut::reporter<boost::ut::printer>
+        {
+        private:
+            TestName currentTest;
+
+        public:
+            auto on(boost::ut::events::test_begin test_begin) -> void
+            {
+                std::string name = std::string(test_begin.name);
+                currentTest.sections.emplace_back(name);
+                currentTest.setFileName(test_begin.location.file_name());
+
+                ApprovalTests::FrameworkIntegrations::setCurrentTest(&currentTest);
+                ApprovalTests::FrameworkIntegrations::setTestPassedNotification(
+                    []() { notify_success(); });
+                boost::ut::reporter<boost::ut::printer>::on(test_begin);
+            }
+
+            auto on(boost::ut::events::test_run test_run) -> void
+            {
+                boost::ut::reporter<boost::ut::printer>::on(test_run);
+            }
+
+            auto on(boost::ut::events::test_skip test_skip) -> void
+            {
+                boost::ut::reporter<boost::ut::printer>::on(test_skip);
+            }
+
+            auto on(boost::ut::events::test_end test_end) -> void
+            {
+                while (!currentTest.sections.empty())
+                {
+                    currentTest.sections.pop_back();
+                }
+                boost::ut::reporter<boost::ut::printer>::on(test_end);
+            }
+
+            template <class TMsg> auto on(boost::ut::events::log<TMsg> log) -> void
+            {
+                boost::ut::reporter<boost::ut::printer>::on(log);
+            }
+
+            template <class TExpr>
+            auto on(boost::ut::events::assertion_pass<TExpr> location) -> void
+            {
+                boost::ut::reporter<boost::ut::printer>::on(location);
+            }
+
+            template <class TExpr>
+            auto on(boost::ut::events::assertion_fail<TExpr> fail) -> void
+            {
+                boost::ut::reporter<boost::ut::printer>::on(fail);
+            }
+
+            auto on(boost::ut::events::fatal_assertion fatal) -> void
+            {
+                boost::ut::reporter<boost::ut::printer>::on(fatal);
+            }
+
+            auto on(boost::ut::events::exception exception) -> void
+            {
+                boost::ut::reporter<boost::ut::printer>::on(exception);
+            }
+
+            auto on(boost::ut::events::summary summary) -> void
+            {
+                boost::ut::reporter<boost::ut::printer>::on(summary);
+            }
+        };
+    } // namespace cfg
+}
+
+template <>
+auto boost::ut::cfg<boost::ut::override> =
+    boost::ut::runner<ApprovalTests::cfg::reporter>{};
+
+namespace ApprovalTests
+{
+    namespace cfg
+    {
+        void notify_success()
+        {
+            // This needs to be after the registering of our custom listener,
+            // for compilation to succeed.
+            boost::ut::expect(true);
+        }
+    }
+}
+
+#endif // APPROVALS_UT
+
+// ******************** From: HelpMessages.h
+
+#include <string>
+#include <vector>
+
+namespace ApprovalTests
+{
+    class HelpMessages
+    {
+    public:
+        static std::string getMisconfiguredBuildHelp(const std::string& fileName);
+
+        static std::string getMisconfiguredMainHelp();
+
+        static std::string getUnconfiguredRootDirectory();
+
+        static std::string
+        getUnknownEnvVarReporterHelp(const std::string& envVarName,
+                                     const std::string& selected,
+                                     const std::vector<std::string>& knowns);
+        static std::string
+        getInvalidEnvVarReporterHelp(const std::string& envVarName,
+                                     const std::string& selected,
+                                     const std::vector<std::string>& knowns);
+
+        static std::string envVarErrorMessage(const std::string& envVarName,
+                                              const std::string& selected,
+                                              const std::vector<std::string>& knowns,
+                                              std::string& helpMessage);
+
+        static std::string topAndTailHelpMessage(const std::string& message);
+    };
+}
+
+// ******************** From: SeparateApprovedAndReceivedDirectoriesNamer.h
+
+
+namespace ApprovalTests
+{
+    class SeparateApprovedAndReceivedDirectoriesNamer : public TemplatedCustomNamer
+    {
+    public:
+        SeparateApprovedAndReceivedDirectoriesNamer();
+
+        virtual ~SeparateApprovedAndReceivedDirectoriesNamer() override = default;
+
+        static DefaultNamerDisposer useAsDefaultNamer();
+    };
+}
+
+// ******************** From: AutoApproveIfMissingReporter.h
+
+
+namespace ApprovalTests
+{
+    class AutoApproveIfMissingReporter : public Reporter
+    {
+    public:
+        bool report(std::string received, std::string approved) const override;
+    };
+}
+
+// ******************** From: BlockingReporter.h
+
+
+#include <memory>
+#include <utility>
+
+namespace ApprovalTests
+{
+    class BlockingReporter : public Reporter
+    {
+    private:
+        std::shared_ptr<Blocker> blocker;
+
+        BlockingReporter() = delete;
+
+    public:
+        explicit BlockingReporter(std::shared_ptr<Blocker> blocker_);
+
+        static std::shared_ptr<BlockingReporter>
+        onMachineNamed(const std::string& machineName);
+
+        static std::shared_ptr<BlockingReporter>
+        onMachinesNotNamed(const std::string& machineName);
+
+        virtual bool report(std::string /*received*/,
+                            std::string /*approved*/) const override;
+    };
+}
+
+// ******************** From: CIBuildOnlyReporter.h
+
+
+#include <memory>
+
+namespace ApprovalTests
+{
+    // A reporter which uses the supplied reporter, if called on a supported Continuous Integration system
+    class CIBuildOnlyReporter : public Reporter
+    {
+    private:
+        std::shared_ptr<Reporter> m_reporter;
+
+    public:
+        explicit CIBuildOnlyReporter(
+            std::shared_ptr<Reporter> reporter = std::make_shared<TextDiffReporter>());
+
+        bool report(std::string received, std::string approved) const override;
+
+        static bool isRunningUnderCI();
+    };
+} // namespace ApprovalTests
+
+// ******************** From: CIBuildOnlyReporterUtils.h
+
+
+namespace ApprovalTests
+{
+    namespace CIBuildOnlyReporterUtils
+    {
+        FrontLoadedReporterDisposer
+        useAsFrontLoadedReporter(const std::shared_ptr<Reporter>& reporter);
+    }
+} // namespace ApprovalTests
+
+// ******************** From: ClipboardReporter.h
+
+
+#include <string>
+
+namespace ApprovalTests
+{
+    class ClipboardReporter : public Reporter
+    {
+    public:
+        static std::string getCommandLineFor(const std::string& received,
+                                             const std::string& approved,
+                                             bool isWindows);
+
+        virtual bool report(std::string received, std::string approved) const override;
+
+        static void copyToClipboard(const std::string& newClipboard);
+    };
+}
+
+// ******************** From: CombinationReporter.h
+
+#include <memory>
+#include <vector>
+
+namespace ApprovalTests
+{
+    class CombinationReporter : public Reporter
+    {
+    private:
+        std::vector<std::unique_ptr<Reporter>> reporters;
+
+    public:
+        // Note that CombinationReporter takes ownership of the given Reporter objects
+        explicit CombinationReporter(const std::vector<Reporter*>& theReporters);
+
+        bool report(std::string received, std::string approved) const override;
+    };
+}
+
+// ******************** From: CustomReporter.h
+
+#include <memory>
+
+namespace ApprovalTests
+{
+    class CustomReporter
+    {
+    public:
+        static std::shared_ptr<GenericDiffReporter> create(std::string path,
+                                                           Type type = Type::TEXT);
+
+        static std::shared_ptr<GenericDiffReporter>
+        create(std::string path, std::string arguments, Type type = Type::TEXT);
+
+        static std::shared_ptr<GenericDiffReporter> createForegroundReporter(
+            std::string path, Type type = Type::TEXT, bool allowNonZeroExitCodes = false);
+
+        static std::shared_ptr<GenericDiffReporter>
+        createForegroundReporter(std::string path,
+                                 std::string arguments,
+                                 Type type = Type::TEXT,
+                                 bool allowNonZeroExitCodes = false);
+    };
+}
+
+// ******************** From: DiffReporter.h
+
+
+namespace ApprovalTests
+{
+    class DiffReporter : public FirstWorkingReporter
+    {
+    public:
+        DiffReporter();
+    };
+}
+
+// ******************** From: EnvironmentVariableReporter.h
+
+#include <memory>
+
+namespace ApprovalTests
+{
+    class EnvironmentVariableReporter : public Reporter
+    {
+    public:
+        bool report(std::string received, std::string approved) const override;
+
+        bool report(const std::string& envVar,
+                    const std::string& received,
+                    const std::string& approved) const;
+
+        static std::string environmentVariableName();
+
+    private:
+        ReporterFactory factory;
+    };
+}
+
+// ******************** From: LinuxReporters.h
+
+
+namespace ApprovalTests
+{
+    namespace Linux
+    {
+        class SublimeMergeSnapReporter : public GenericDiffReporter
+        {
+        public:
+            SublimeMergeSnapReporter();
+        };
+
+        class SublimeMergeFlatpakReporter : public GenericDiffReporter
+        {
+        public:
+            SublimeMergeFlatpakReporter();
+        };
+
+        class SublimeMergeRepositoryPackageReporter : public GenericDiffReporter
+        {
+        public:
+            SublimeMergeRepositoryPackageReporter();
+        };
+
+        class SublimeMergeDirectDownloadReporter : public GenericDiffReporter
+        {
+        public:
+            SublimeMergeDirectDownloadReporter();
+        };
+
+        class SublimeMergeReporter : public FirstWorkingReporter
+        {
+        public:
+            SublimeMergeReporter();
+        };
+
+        class KDiff3Reporter : public GenericDiffReporter
+        {
+        public:
+            KDiff3Reporter();
+        };
+
+        class MeldReporter : public GenericDiffReporter
+        {
+        public:
+            MeldReporter();
+        };
+
+        class BeyondCompareReporter : public GenericDiffReporter
+        {
+        public:
+            BeyondCompareReporter();
+        };
+
+        class LinuxDiffReporter : public FirstWorkingReporter
+        {
+        public:
+            LinuxDiffReporter();
+        };
+    }
+}
+
+// ******************** From: MacReporters.h
+
+
+namespace ApprovalTests
+{
+    namespace Mac
+    {
+        class DiffMergeReporter : public GenericDiffReporter
+        {
+        public:
+            DiffMergeReporter();
+        };
+
+        class AraxisMergeReporter : public GenericDiffReporter
+        {
+        public:
+            AraxisMergeReporter();
+        };
+
+        class VisualStudioCodeReporter : public GenericDiffReporter
+        {
+        public:
+            VisualStudioCodeReporter();
+        };
+
+        class BeyondCompareReporter : public GenericDiffReporter
+        {
+        public:
+            BeyondCompareReporter();
+        };
+
+        class KaleidoscopeReporter : public GenericDiffReporter
+        {
+        public:
+            KaleidoscopeReporter();
+        };
+
+        class SublimeMergeReporter : public GenericDiffReporter
+        {
+        public:
+            SublimeMergeReporter();
+        };
+
+        class KDiff3Reporter : public GenericDiffReporter
+        {
+        public:
+            KDiff3Reporter();
+        };
+
+        class P4MergeReporter : public GenericDiffReporter
+        {
+        public:
+            P4MergeReporter();
+        };
+
+        class TkDiffReporter : public GenericDiffReporter
+        {
+        public:
+            TkDiffReporter();
+        };
+
+        // Note that this will be found on Linux too.
+        // See https://github.com/approvals/ApprovalTests.cpp/issues/138 for limitations
+        class CLionDiffReporter : public GenericDiffReporter
+        {
+        public:
+            CLionDiffReporter();
+        };
+
+        class MacDiffReporter : public FirstWorkingReporter
+        {
+        public:
+            MacDiffReporter();
+
+            bool report(std::string received, std::string approved) const override;
+        };
+    }
+}
+
+// ******************** From: WindowsReporters.h
+
+
+namespace ApprovalTests
+{
+    namespace Windows
+    {
+
+        class VisualStudioCodeReporter : public GenericDiffReporter
+        {
+        public:
+            VisualStudioCodeReporter();
+        };
+
+        // ----------------------- Beyond Compare ----------------------------------
+        class BeyondCompare3Reporter : public GenericDiffReporter
+        {
+        public:
+            BeyondCompare3Reporter();
+        };
+
+        class BeyondCompare4Reporter : public GenericDiffReporter
+        {
+        public:
+            BeyondCompare4Reporter();
+        };
+
+        class BeyondCompareReporter : public FirstWorkingReporter
+        {
+        public:
+            BeyondCompareReporter();
+        };
+
+        // ----------------------- Tortoise SVN ------------------------------------
+        class TortoiseImageDiffReporter : public GenericDiffReporter
+        {
+        public:
+            TortoiseImageDiffReporter();
+        };
+
+        class TortoiseTextDiffReporter : public GenericDiffReporter
+        {
+        public:
+            TortoiseTextDiffReporter();
+        };
+
+        class TortoiseDiffReporter : public FirstWorkingReporter
+        {
+        public:
+            TortoiseDiffReporter();
+        };
+
+        // ----------------------- Tortoise Git ------------------------------------
+        class TortoiseGitTextDiffReporter : public GenericDiffReporter
+        {
+        public:
+            TortoiseGitTextDiffReporter();
+        };
+
+        class TortoiseGitImageDiffReporter : public GenericDiffReporter
+        {
+        public:
+            TortoiseGitImageDiffReporter();
+        };
+
+        class TortoiseGitDiffReporter : public FirstWorkingReporter
+        {
+        public:
+            TortoiseGitDiffReporter();
+        };
+
+        // -------------------------------------------------------------------------
+        class WinMergeReporter : public GenericDiffReporter
+        {
+        public:
+            WinMergeReporter();
+        };
+
+        class AraxisMergeReporter : public GenericDiffReporter
+        {
+        public:
+            AraxisMergeReporter();
+        };
+
+        class CodeCompareReporter : public GenericDiffReporter
+        {
+        public:
+            CodeCompareReporter();
+        };
+
+        class SublimeMergeReporter : public GenericDiffReporter
+        {
+        public:
+            SublimeMergeReporter();
+        };
+
+        class KDiff3Reporter : public GenericDiffReporter
+        {
+        public:
+            KDiff3Reporter();
+        };
+
+        class WindowsDiffReporter : public FirstWorkingReporter
+        {
+        public:
+            WindowsDiffReporter();
+
+            bool report(std::string received, std::string approved) const override;
+        };
+    }
+}
+
+// ******************** From: DateUtils.h
+
+#include <chrono>
+#include <string>
+
+namespace ApprovalTests
+{
+    // All values are in UTC
+    class DateUtils
+    {
+    public:
+        static std::tm
+        createTm(int year, int month, int day, int hour, int minute, int second);
+
+        static std::chrono::system_clock::time_point
+        createUtcDateTime(int year, int month, int day, int hour, int minute, int second);
+
+        static std::string toString(const std::chrono::system_clock::time_point& dateTime,
+                                    const std::string& format);
+
+        static std::string
+        toString(const std::chrono::system_clock::time_point& dateTime);
+
+        static time_t toUtc(std::tm& timeinfo);
+
+        static tm toUtc(time_t& tt);
+    };
+}
+
+// ******************** From: EmptyFileCreatorByType.h
+
+
+#include <map>
+#include <string>
+
+namespace ApprovalTests
+{
+    class EmptyFileCreatorByType
+    {
+    private:
+        static std::map<std::string, EmptyFileCreator> creators_;
+
+    public:
+        static void registerCreator(const std::string& extensionWithDot,
+                                    EmptyFileCreator creator);
+
+        static void createFile(const std::string& fileName);
+    };
+}
+
+// ******************** From: ExceptionCollector.h
+
+#include <sstream>
+#include <exception>
+#include <string>
+#include <vector>
+#include <functional>
+
+namespace ApprovalTests
+{
+    class ExceptionCollector
+    {
+        std::vector<std::string> exceptionMessages;
+
+    public:
+        void gather(std::function<void(void)> functionThatThrows);
+
+        ~ExceptionCollector();
+
+        void release();
+    };
+}
+
+// ******************** From: FileUtilsSystemSpecific.h
+
+
+namespace ApprovalTests
+{
+    class FileUtilsSystemSpecific
+    {
+    public:
+        static std::string getCommandLineForCopy(const std::string& source,
+                                                 const std::string& destination,
+                                                 bool isWindows);
+
+        static void copyFile(const std::string& source, const std::string& destination);
+    };
+}
+
+// ******************** From: Grid.h
+#include <sstream>
+#include <functional>
+
+namespace ApprovalTests
+{
+    class Grid
+    {
+    public:
+        static std::string print(int width,
+                                 int height,
+                                 std::function<void(int, int, std::ostream&)> printCell);
+        static std::string print(int width, int height, std::string text);
+    };
+}
+
+#ifdef APPROVAL_TESTS_INCLUDE_CPPS
+
+// ******************** From: ApprovalUtils.cpp
+
+#include <ostream>
+
+namespace ApprovalTests
+{
+    void ApprovalUtils::writeHeader(std::ostream& stream, const std::string& header)
+    {
+        if (!header.empty())
+        {
+            stream << header << "\n\n\n";
+        }
+    }
+}
+
+// ******************** From: Storyboard.cpp
+
+namespace ApprovalTests
+{
+    Storyboard& Storyboard::addDescription(const std::string& description)
+    {
+        output_ << description << "\n";
+        addNewLineBeforeNextFrame_ = true;
+        return *this;
+    }
+
+    Storyboard& Storyboard::addDescriptionWithData(const std::string& description,
+                                                   const std::string& data)
+    {
+        output_ << description << ": " << data << "\n";
+        addNewLineBeforeNextFrame_ = true;
+        return *this;
+    }
+
+    Storyboard& Storyboard::addFrame(const std::string& frame)
+    {
+        if (frameCount_ == 0)
+        {
+            return addFrame("Initial Frame", frame);
+        }
+        else
+        {
+            return addFrame("Frame #" + std::to_string(frameCount_), frame);
+        }
+    }
+
+    Storyboard& Storyboard::addFrame(const std::string& title, const std::string& frame)
+    {
+        if (addNewLineBeforeNextFrame_)
+        {
+            output_ << '\n';
+            addNewLineBeforeNextFrame_ = false;
+        }
+        output_ << title << ":\n";
+        output_ << frame << "\n\n";
+        frameCount_ += 1;
+        return *this;
+    }
+
+    Storyboard& Storyboard::addFrames(int numberOfFrames,
+                                      const std::function<std::string(int)>& function)
+    {
+        for (int frame = 1; frame <= numberOfFrames; ++frame)
+        {
+            addFrame(function(frame));
+        }
+        return *this;
+    }
+
+    std::ostream& operator<<(std::ostream& os, const Storyboard& board)
+    {
+        os << board.output_.str();
+        return os;
+    }
+}
+
+// ******************** From: ComparatorDisposer.cpp
+
+namespace ApprovalTests
+{
+    ComparatorDisposer::ComparatorDisposer(
+        ComparatorContainer& comparators_,
+        const std::string& extensionWithDot,
+        std::shared_ptr<ApprovalTests::ApprovalComparator> previousComparator_,
+        std::shared_ptr<ApprovalTests::ApprovalComparator> newComparator)
+        : comparators(comparators_)
+        , ext_(extensionWithDot)
+        , previousComparator(std::move(previousComparator_))
+    {
+        comparators_[extensionWithDot] = std::move(newComparator);
+    }
+
+    ComparatorDisposer::ComparatorDisposer(ComparatorDisposer&& other) noexcept
+        : comparators(other.comparators)
+        , ext_(std::move(other.ext_))
+        , previousComparator(std::move(other.previousComparator))
+    {
+        other.isActive = false;
+    }
+
+    ComparatorDisposer::~ComparatorDisposer()
+    {
+        if (isActive)
+        {
+            comparators[ext_] = previousComparator;
+        }
+    }
+}
+
+// ******************** From: ComparatorFactory.cpp
+
+namespace ApprovalTests
+{
+    ComparatorContainer& ComparatorFactory::comparators()
+    {
+        static ComparatorContainer allComparators;
+        return allComparators;
+    }
+
+    ComparatorDisposer
+    ComparatorFactory::registerComparator(const std::string& extensionWithDot,
+                                          std::shared_ptr<ApprovalComparator> comparator)
+    {
+        return ComparatorDisposer(comparators(),
+                                  extensionWithDot,
+                                  getComparatorForFileExtensionWithDot(extensionWithDot),
+                                  comparator);
+    }
+
+    std::shared_ptr<ApprovalComparator>
+    ComparatorFactory::getComparatorForFile(const std::string& receivedPath)
+    {
+        const std::string fileExtension = FileUtils::getExtensionWithDot(receivedPath);
+        return getComparatorForFileExtensionWithDot(fileExtension);
+    }
+
+    std::shared_ptr<ApprovalComparator>
+    ComparatorFactory::getComparatorForFileExtensionWithDot(
+        const std::string& fileExtensionWithDot)
+    {
+        auto iterator = comparators().find(fileExtensionWithDot);
+        if (iterator != comparators().end())
+        {
+            return iterator->second;
+        }
+        return std::make_shared<TextFileComparator>();
+    }
+}
+
+// ******************** From: TextFileComparator.cpp
+
+#include <fstream>
+
+namespace ApprovalTests
+{
+    std::ifstream::int_type
+    TextFileComparator::getNextRelevantCharacter(std::ifstream& astream)
+    {
+        auto ch = astream.get();
+        if (ch == '\r')
+        {
+            return astream.get();
+        }
+        else
+        {
+            return ch;
+        }
+    }
+
+    bool TextFileComparator::contentsAreEquivalent(std::string receivedPath,
+                                                   std::string approvedPath) const
+    {
+        std::ifstream astream(approvedPath.c_str(), std::ios::binary | std::ifstream::in);
+        std::ifstream rstream(receivedPath.c_str(), std::ios::binary | std::ifstream::in);
+
+        while (astream.good() && rstream.good())
+        {
+            int a = getNextRelevantCharacter(astream);
+            int r = getNextRelevantCharacter(rstream);
+
+            if (a != r)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
+// ******************** From: ApprovalException.cpp
+
+#include <sstream>
+
+namespace ApprovalTests
+{
+    ApprovalException::ApprovalException(const std::string& msg) : message(msg)
+    {
+    }
+
+    const char* ApprovalException::what() const noexcept
+    {
+        return message.c_str();
+    }
+
+    std::string ApprovalMismatchException::format(const std::string& received,
+                                                  const std::string& approved)
+    {
+        std::stringstream s;
+        s << "Failed Approval: \n"
+          << "Received does not match approved \n"
+          << "Received : \"" << received << "\" \n"
+          << "Approved : \"" << approved << "\"";
+        return s.str();
+    }
+
+    ApprovalMismatchException::ApprovalMismatchException(const std::string& received,
+                                                         const std::string& approved)
+        : ApprovalException(format(received, approved))
+    {
+    }
+
+    std::string ApprovalMissingException::format(const std::string& file)
+    {
+        std::stringstream s;
+        s << "Failed Approval: \n"
+          << "Approval File Not Found \n"
+          << "File: \"" << file << '"';
+        return s.str();
+    }
+
+    ApprovalMissingException::ApprovalMissingException(const std::string&,
+                                                       const std::string& approved)
+        : ApprovalException(format(approved))
+    {
+    }
+}
+
+// ******************** From: FileApprover.cpp
+
+#include <sstream>
+
+namespace ApprovalTests
+{
+
+    ComparatorDisposer FileApprover::registerComparatorForExtension(
+        const std::string& extensionWithDot,
+        std::shared_ptr<ApprovalComparator> comparator)
+    {
+        return ComparatorFactory::registerComparator(extensionWithDot, comparator);
+    }
+
+    FileApprover::TestPassedNotification FileApprover::testPassedNotification_ = []() {};
+
+    void FileApprover::verify(const std::string& receivedPath,
+                              const std::string& approvedPath,
+                              const ApprovalComparator& comparator)
+    {
+        if (receivedPath == approvedPath)
+        {
+            std::stringstream s;
+            s << "Identical filenames for received and approved.\n"
+              << "Tests would spuriously pass. \n"
+              << "Please check your custom namer. \n"
+              << "Received : \"" << receivedPath << "\" \n"
+              << "Approved : \"" << approvedPath << "\"";
+            // Do not throw ApprovalException, as we don't want reporters to trigger.
+            // They would show two seemingly identical files, due to matching file name.
+            throw std::runtime_error(s.str());
+        }
+
+        if (!FileUtils::fileExists(approvedPath))
+        {
+            throw ApprovalMissingException(receivedPath, approvedPath);
+        }
+
+        if (!FileUtils::fileExists(receivedPath))
+        {
+            throw ApprovalMissingException(approvedPath, receivedPath);
+        }
+
+        if (!comparator.contentsAreEquivalent(receivedPath, approvedPath))
+        {
+            throw ApprovalMismatchException(receivedPath, approvedPath);
+        }
+    }
+
+    void FileApprover::verify(const std::string& receivedPath,
+                              const std::string& approvedPath)
+    {
+        verify(receivedPath,
+               approvedPath,
+               *ComparatorFactory::getComparatorForFile(receivedPath));
+    }
+
+    void FileApprover::verify(const ApprovalNamer& n,
+                              const ApprovalWriter& s,
+                              const Reporter& r)
+    {
+        std::string approvedPath = n.getApprovedFile(s.getFileExtensionWithDot());
+        std::string receivedPath = n.getReceivedFile(s.getFileExtensionWithDot());
+        SystemUtils::ensureParentDirectoryExists(approvedPath);
+        SystemUtils::ensureParentDirectoryExists(receivedPath);
+        s.write(receivedPath);
+        try
+        {
+            verify(receivedPath, approvedPath);
+            s.cleanUpReceived(receivedPath);
+            notifyTestPassed();
+        }
+        catch (const ApprovalException&)
+        {
+            reportAfterTryingFrontLoadedReporter(receivedPath, approvedPath, r);
+            throw;
+        }
+    }
+
+    void
+    FileApprover::reportAfterTryingFrontLoadedReporter(const std::string& receivedPath,
+                                                       const std::string& approvedPath,
+                                                       const Reporter& r)
+    {
+        auto tryFirst = FrontLoadedReporterFactory::getFrontLoadedReporter();
+        if (!tryFirst->report(receivedPath, approvedPath))
+        {
+            r.report(receivedPath, approvedPath);
+        }
+    }
+
+    void FileApprover::setTestPassedNotification(
+        FileApprover::TestPassedNotification notification)
+    {
+        testPassedNotification_ = notification;
+    }
+
+    void FileApprover::notifyTestPassed()
+    {
+        testPassedNotification_();
+    }
+}
+
+// ******************** From: Options.cpp
+
+namespace ApprovalTests
+{
+    // FileOptions -----------------------------------------------------------------------
+    Options::FileOptions::FileOptions(std::string fileExtensionWithDot)
+        : fileExtensionWithDot_(std::move(fileExtensionWithDot))
+    {
+    }
+
+    Options::FileOptions Options::FileOptions::clone() const
+    {
+        // the returned options_ must be null
+        return FileOptions(fileExtensionWithDot_);
+    }
+
+    const std::string& Options::FileOptions::getFileExtension() const
+    {
+        return fileExtensionWithDot_;
+    }
+
+    Options
+    Options::FileOptions::withFileExtension(const std::string& fileExtensionWithDot) const
+    {
+        FileOptions newSelf(fileExtensionWithDot);
+        return options_->clone(newSelf);
+    }
+
+    // Options ---------------------------------------------------------------------------
+    Options::Options(Options::FileOptions fileOptions,
+                     Scrubber scrubber,
+                     const Reporter& reporter,
+                     bool usingDefaultScrubber,
+                     std::shared_ptr<ApprovalNamer> namer)
+        : fileOptions_(std::move(fileOptions))
+        , scrubber_(std::move(scrubber))
+        , reporter_(reporter)
+        , namer_(namer)
+        , usingDefaultScrubber_(usingDefaultScrubber)
+    {
+    }
+
+    Options Options::clone(const Options::FileOptions& fileOptions) const
+    {
+        // TODO error this can retain a previous Options* ???
+        return Options(fileOptions, scrubber_, reporter_, usingDefaultScrubber_, namer_);
+    }
+
+    const Reporter& Options::defaultReporter()
+    {
+        static DefaultReporter defaultReporter;
+        return defaultReporter;
+    }
+
+    Options::Options(Scrubber scrubber) : scrubber_(std::move(scrubber))
+    {
+        usingDefaultScrubber_ = false;
+    }
+
+    Options::Options(const Reporter& reporter) : reporter_(reporter)
+    {
+    }
+
+    Options::FileOptions Options::fileOptions() const
+    {
+        if (fileOptions_.options_ != nullptr)
+        {
+            throw std::logic_error(
+                "Incorrect assumption: A FileOptions has been re-used");
+        }
+        FileOptions copy = fileOptions_.clone();
+        copy.options_ = this;
+        return copy;
+    }
+
+    Scrubber Options::getScrubber() const
+    {
+        return scrubber_;
+    }
+
+    bool Options::isUsingDefaultScrubber() const
+    {
+        return usingDefaultScrubber_;
+    }
+
+    std::string Options::scrub(const std::string& input) const
+    {
+        return scrubber_(input);
+    }
+    const Reporter& Options::getReporter() const
+    {
+        return reporter_;
+    }
+
+    Options Options::withReporter(const Reporter& reporter) const
+    {
+        return Options(fileOptions_, scrubber_, reporter, usingDefaultScrubber_, namer_);
+    }
+
+    Options Options::withScrubber(Scrubber scrubber) const
+    {
+        return Options(fileOptions_, std::move(scrubber), reporter_, false, namer_);
+    }
+
+    std::shared_ptr<ApprovalNamer> Options::getNamer() const
+    {
+        return namer_;
+    }
+
+    Options Options::withNamer(std::shared_ptr<ApprovalNamer> namer)
+    {
+        return Options(
+            fileOptions_, scrubber_, reporter_, usingDefaultScrubber_, std::move(namer));
+    }
+}
+
+// ******************** From: FrameworkIntegrations.cpp
+
+namespace ApprovalTests
+{
+    void FrameworkIntegrations::setTestPassedNotification(
+        FileApprover::TestPassedNotification notification)
+    {
+        FileApprover::setTestPassedNotification(notification);
+    }
+
+    void FrameworkIntegrations::setCurrentTest(ApprovalTests::TestName* currentTest)
+    {
+        ApprovalTestNamer::currentTest(currentTest);
+    }
+}
+
+// ******************** From: GoogleConfiguration.cpp
+
+namespace ApprovalTests
+{
+    bool GoogleConfiguration::addTestCaseNameRedundancyCheck(
+        GoogleCustomizationsFactory::Comparator comparator)
+    {
+        return GoogleCustomizationsFactory::addTestCaseNameRedundancyCheck(comparator);
+    }
+
+    bool GoogleConfiguration::addIgnorableTestCaseNameSuffix(std::string suffix)
+    {
+        return addTestCaseNameRedundancyCheck(
+            createIgnorableTestCaseNameSuffixCheck(suffix));
+    }
+
+    GoogleCustomizationsFactory::Comparator
+    GoogleConfiguration::createIgnorableTestCaseNameSuffixCheck(const std::string& suffix)
+    {
+        return [suffix](std::string testFileNameWithExtension, std::string testCaseName) {
+            if (testCaseName.length() <= suffix.length() ||
+                !StringUtils::endsWith(testCaseName, suffix))
+            {
+                return false;
+            }
+
+            auto withoutSuffix =
+                testCaseName.substr(0, testCaseName.length() - suffix.length());
+            auto withFileExtension = withoutSuffix + ".";
+            return StringUtils::contains(testFileNameWithExtension, withFileExtension);
+        };
+    }
+}
+
+// ******************** From: GoogleCustomizationsFactory.cpp
+
+namespace ApprovalTests
+{
+    GoogleCustomizationsFactory::ComparatorContainer&
+    GoogleCustomizationsFactory::comparatorContainer()
+    {
+        static ComparatorContainer container;
+        if (container.empty())
+        {
+            auto exactNameMatching = [](const std::string& testFileNameWithExtension,
+                                        const std::string& testCaseName) {
+                return StringUtils::contains(testFileNameWithExtension,
+                                             testCaseName + ".");
+            };
+            container.push_back(exactNameMatching);
+        }
         return container;
     }
 
-public:
-    static ComparatorContainer getEquivalencyChecks()
+    GoogleCustomizationsFactory::ComparatorContainer
+    GoogleCustomizationsFactory::getEquivalencyChecks()
     {
         return comparatorContainer();
     }
 
-    static bool addTestCaseNameRedundancyCheck(Comparator comparator)
+    bool GoogleCustomizationsFactory::addTestCaseNameRedundancyCheck(
+        const GoogleCustomizationsFactory::Comparator& comparator)
     {
         comparatorContainer().push_back(comparator);
         return true;
     }
-    
+}
 
-};
+// ******************** From: SystemLauncher.cpp
 
-#endif 
-
- // ******************** From: ExistingFile.h
-#ifndef APPROVALTESTS_CPP_EXISTINGFILE_H
-#define APPROVALTESTS_CPP_EXISTINGFILE_H
-
-
-
-class ExistingFile : public ApprovalWriter{
-    std::string filePath;
-public:
-    ExistingFile(std::string filePath) : filePath(filePath){}
-    virtual std::string getFileExtensionWithDot() override {
-        return FileUtils::getExtensionWithDot(filePath);
-    }
-    virtual void write(std::string ) override {
-        
-    }
-    virtual void cleanUpReceived(std::string ) override {
-        
-    }
-};
-#endif
-
- // ******************** From: CommandLauncher.h
-#ifndef APPROVALTESTS_CPP_COMMANDLAUNCHER_H
-#define APPROVALTESTS_CPP_COMMANDLAUNCHER_H
-
-
-
-class CommandLauncher
+namespace ApprovalTests
 {
-public:
-    virtual ~CommandLauncher() {}
-    virtual bool launch(std::vector<std::string> argv) = 0;
-};
-
-#endif  
-
- // ******************** From: CommandReporter.h
-#ifndef APPROVALTESTS_CPP_COMMANDREPORTER_H
-#define APPROVALTESTS_CPP_COMMANDREPORTER_H
-
-
-
-class CommandReporter : public Reporter {
-private:
-    std::string cmd;
-    CommandLauncher *l;
-
-protected:
-    CommandReporter(std::string command, CommandLauncher *launcher)
-            : cmd(command), l(launcher) {
-    }
-
-public:
-    bool report(std::string received, std::string approved) const override {
-        FileUtils::ensureFileExists(approved);
-        return l->launch(getFullCommand(received, approved));
-    }
-
-    std::vector<std::string> getFullCommand(const std::string &received, const std::string &approved) const
-    {
-        std::vector<std::string> fullCommand;
-        fullCommand.push_back(cmd);
-        fullCommand.push_back(received);
-        fullCommand.push_back(approved);
-        return fullCommand;
-    }
-};
-#endif 
-
- // ******************** From: SystemLauncher.h
-
-#ifndef APPROVALTESTS_CPP_SYSTEMLAUNCHER_H
-#define APPROVALTESTS_CPP_SYSTEMLAUNCHER_H
-
-
-typedef std::vector<std::string> (*ConvertArgumentsFunctionPointer)(std::vector<std::string>);
-
-class SystemLauncher : public CommandLauncher
-{
-private:
-    ConvertArgumentsFunctionPointer convertArgumentsForSystemLaunching;
-public:
-    SystemLauncher() : SystemLauncher(doNothing)
+    SystemLauncher::SystemLauncher(bool isForeground, bool allowNonZeroExitCodes)
+        : isForeground_(isForeground), allowNonZeroExitCodes_(allowNonZeroExitCodes)
     {
     }
 
-    explicit SystemLauncher(std::vector<std::string> (*pointer)(std::vector<std::string>)) : convertArgumentsForSystemLaunching(pointer) 
+    bool SystemLauncher::launch(const std::string& commandLine)
     {
-    }
+        std::string launch = getCommandLine(commandLine);
 
-    
-    void setConvertArgumentsForSystemLaunchingFunction(ConvertArgumentsFunctionPointer function)
-    {
-        convertArgumentsForSystemLaunching = function;
-    }
-
-    bool exists(const std::string& command)
-    {
-        bool foundByWhich = false;
-        if (!SystemUtils::isWindowsOs()) {
-            std::string which = "which " + command + " > /dev/null 2>&1";
-            int result = system(which.c_str());
-            foundByWhich = (result == 0);
-        }
-        return  foundByWhich || FileUtils::fileExists(command);
-
-    }
-
-    static std::vector<std::string> doNothing(std::vector<std::string> argv)
-    {
-        return argv;
-    }
-
-    bool launch(std::vector<std::string> argv) override
-    {
-        if (!exists(argv.front()))
-        {
-            return false;
-        }
-
-        argv = convertArgumentsForSystemLaunching(argv);
-
-        std::string command = std::accumulate(argv.begin(), argv.end(), std::string(""), [](std::string a, std::string b) {return a + " " + "\"" + b + "\""; });
-        std::string launch = SystemUtils::isWindowsOs() ? ("start \"\" " +  command) :  (command + " &");
-        system(launch.c_str());
+        SystemUtils::runSystemCommandOrThrow(launch, allowNonZeroExitCodes_);
         return true;
     }
-};
 
-#endif 
-
- // ******************** From: DiffInfo.h
-#ifndef APPROVALTESTS_CPP_DIFFINFO_H
-#define APPROVALTESTS_CPP_DIFFINFO_H
-
-
-enum class Type { TEXT, IMAGE, TEXT_AND_IMAGE };
-
-
-
-struct DiffInfo
-{
-    DiffInfo(std::string program, Type type) :
-        program(program),
-        arguments("%s %s"),
-        type(type)
+    void SystemLauncher::invokeForWindows(bool useWindows)
     {
+        useWindows_ = useWindows;
     }
-    DiffInfo(std::string program, std::string arguments, Type type) :
-        program(program),
-        arguments(arguments),
-        type(type)
+
+    void SystemLauncher::setForeground(bool foreground)
     {
+        isForeground_ = foreground;
     }
-    std::string program;
-    std::string arguments;
-    Type type;
 
-    std::string getProgramForOs() const
+    void SystemLauncher::setAllowNonZeroExitCodes(bool allow)
     {
-        std::string result = program;
-        if (result.rfind("{ProgramFiles}", 0) == 0)
-        {
-            const std::vector<const char*> envVars =
-            {
-                "ProgramFiles",
-                "ProgramW6432",
-                "ProgramFiles(x86)"
-            };
-
-            for(const auto& envVar : envVars)
-            {
-                std::string envVarValue = SystemUtils::safeGetEnv(envVar);
-                if (envVarValue.empty())
-                {
-                    continue;
-                }
-                envVarValue += '\\';
-
-                auto result1 = StringUtils::replaceAll(result, "{ProgramFiles}", envVarValue);
-                if (FileUtils::fileExists(result1))
-                {
-                    return result1;
-                }
-            }
-        }
-        return result;
+        allowNonZeroExitCodes_ = allow;
     }
-};
 
-
-#endif 
-
- // ******************** From: DiffPrograms.h
-#ifndef APPROVALTESTS_CPP_DIFFPROGRAMS_H
-#define APPROVALTESTS_CPP_DIFFPROGRAMS_H
-
-
-
-#define APPROVAL_TESTS_MACROS_ENTRY(name, defaultValue) \
-        static DiffInfo name() { return defaultValue; }
-
-
-namespace DiffPrograms {
-
-
-    namespace Mac {
-        APPROVAL_TESTS_MACROS_ENTRY(DIFF_MERGE,
-              DiffInfo("/Applications/DiffMerge.app/Contents/MacOS/DiffMerge", "%s %s -nosplash", Type::TEXT))
-
-        APPROVAL_TESTS_MACROS_ENTRY(BEYOND_COMPARE, DiffInfo("/Applications/Beyond Compare.app/Contents/MacOS/bcomp", Type::TEXT))
-
-        APPROVAL_TESTS_MACROS_ENTRY(KALEIDOSCOPE, DiffInfo("/Applications/Kaleidoscope.app/Contents/MacOS/ksdiff", Type::TEXT_AND_IMAGE))
-
-        APPROVAL_TESTS_MACROS_ENTRY(KDIFF3, DiffInfo("/Applications/kdiff3.app/Contents/MacOS/kdiff3", "%s %s -m", Type::TEXT))
-
-        APPROVAL_TESTS_MACROS_ENTRY(P4MERGE, DiffInfo("/Applications/p4merge.app/Contents/MacOS/p4merge", Type::TEXT_AND_IMAGE))
-
-        APPROVAL_TESTS_MACROS_ENTRY(TK_DIFF, DiffInfo("/Applications/TkDiff.app/Contents/MacOS/tkdiff", Type::TEXT))
-
-        APPROVAL_TESTS_MACROS_ENTRY(VS_CODE, DiffInfo("/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code", "-d %s %s", Type::TEXT))
+    bool SystemLauncher::isForeground() const
+    {
+        return isForeground_;
     }
-    namespace Linux {
-        
-        APPROVAL_TESTS_MACROS_ENTRY(KDIFF3, DiffInfo("kdiff3", Type::TEXT))
 
-        APPROVAL_TESTS_MACROS_ENTRY(MELD, DiffInfo("meld", Type::TEXT))
+    std::string SystemLauncher::getCommandLine(const std::string& commandLine) const
+    {
+        std::string launch = useWindows_
+                                 ? getWindowsCommandLine(commandLine, isForeground_)
+                                 : getUnixCommandLine(commandLine, isForeground_);
+        return launch;
     }
-    namespace Windows {
-        APPROVAL_TESTS_MACROS_ENTRY(BEYOND_COMPARE_3, DiffInfo("{ProgramFiles}Beyond Compare 3\\BCompare.exe", Type::TEXT_AND_IMAGE))
 
-        APPROVAL_TESTS_MACROS_ENTRY(BEYOND_COMPARE_4, DiffInfo("{ProgramFiles}Beyond Compare 4\\BCompare.exe", Type::TEXT_AND_IMAGE))
+    std::string SystemLauncher::getWindowsCommandLine(const std::string& commandLine,
+                                                      bool foreground) const
+    {
+        std::string launch = foreground
+                                 ? (std::string("cmd /S /C ") + "\"" + commandLine + "\"")
+                                 : ("start \"\" " + commandLine);
 
-        APPROVAL_TESTS_MACROS_ENTRY(TORTOISE_IMAGE_DIFF,
-              DiffInfo("{ProgramFiles}TortoiseSVN\\bin\\TortoiseIDiff.exe", "/left:%s /right:%s", Type::IMAGE))
+        return launch;
+    }
 
-        APPROVAL_TESTS_MACROS_ENTRY(TORTOISE_TEXT_DIFF, DiffInfo("{ProgramFiles}TortoiseSVN\\bin\\TortoiseMerge.exe", Type::TEXT))
+    std::string SystemLauncher::getUnixCommandLine(const std::string& commandLine,
+                                                   bool foreground) const
+    {
+        std::string launch = foreground ? commandLine : (commandLine + " &");
 
-        APPROVAL_TESTS_MACROS_ENTRY(WIN_MERGE_REPORTER, DiffInfo("{ProgramFiles}WinMerge\\WinMergeU.exe", Type::TEXT_AND_IMAGE))
-
-        APPROVAL_TESTS_MACROS_ENTRY(ARAXIS_MERGE, DiffInfo("{ProgramFiles}Araxis\\Araxis Merge\\Compare.exe", Type::TEXT_AND_IMAGE))
-
-        APPROVAL_TESTS_MACROS_ENTRY(CODE_COMPARE, DiffInfo("{ProgramFiles}Devart\\Code Compare\\CodeCompare.exe", Type::TEXT))
-
-        APPROVAL_TESTS_MACROS_ENTRY(KDIFF3, DiffInfo("{ProgramFiles}KDiff3\\kdiff3.exe", Type::TEXT))
-        APPROVAL_TESTS_MACROS_ENTRY(VS_CODE, DiffInfo("{ProgramFiles}Microsoft VS Code\\Code.exe", "-d %s %s", Type::TEXT))
-
+        return launch;
     }
 }
 
-#endif 
+// ******************** From: ApprovalTestNamer.cpp
 
- // ******************** From: GenericDiffReporter.h
-#ifndef APPROVALTESTS_CPP_GENERICDIFFREPORTER_H
-#define APPROVALTESTS_CPP_GENERICDIFFREPORTER_H
+#include <iostream>
 
-
-class GenericDiffReporter : public CommandReporter {
-private:
-    SystemLauncher launcher;
-public:
-    GenericDiffReporter(const std::string& program) : CommandReporter(program, &launcher)
-    {
-        checkForCygwin();
-    }
-    GenericDiffReporter(const DiffInfo& info) : CommandReporter(info.getProgramForOs().c_str(), &launcher)
-    {
-        checkForCygwin();
-    }
-
-    void checkForCygwin()
-    {
-        if ( SystemUtils::isCygwin())
-        {
-            launcher.setConvertArgumentsForSystemLaunchingFunction(convertForCygwin);
-        }
-    }
-
-    static std::vector<std::string> convertForCygwin(std::vector<std::string> argv)
-    {
-        if (! SystemUtils::isCygwin())
-        {
-            return argv;
-        }
-        std::vector<std::string> copy = argv;
-        for( size_t i = 0; i != argv.size(); ++i )
-        {
-            if ( i == 0)
-            {
-                copy[i] = "$(cygpath '"  + argv[i] + "')";
-            }
-            else
-            {
-                copy[i] = "$(cygpath -aw '"  + argv[i] + "')";
-            }
-        }
-        return copy;
-    }
-};
-
-#endif 
-
- // ******************** From: FirstWorkingReporter.h
-#ifndef APPROVALTESTS_CPP_FIRSTWORKINGREPORTER_H
-#define APPROVALTESTS_CPP_FIRSTWORKINGREPORTER_H
-
-
-class FirstWorkingReporter : public Reporter
+namespace ApprovalTests
 {
-private:
-    std::vector< std::unique_ptr<Reporter> > reporters;
-public:
-    
-    FirstWorkingReporter(std::vector<Reporter*> theReporters)
+    std::string TestName::directoryPrefix;
+    bool TestName::checkBuildConfig_ = true;
+
+    const std::string& TestName::getFileName() const
     {
-        for(auto r : theReporters)
-        {
-            reporters.push_back(std::unique_ptr<Reporter>(r));
-        }
-    }
-
-    bool report(std::string received, std::string approved) const override
-    {
-        for(auto& r : reporters)
-        {
-            if (r->report(received, approved))
-            {
-                return true;
-            }
-        }
-        return false;
-    }
-};
-
-#endif 
-
- // ******************** From: LinuxReporters.h
-#ifndef APPROVALTESTS_CPP_LINUXREPORTERS_H
-#define APPROVALTESTS_CPP_LINUXREPORTERS_H
-
-
-namespace Linux
-{
-    class KDiff3Reporter : public GenericDiffReporter {
-    public:
-        KDiff3Reporter() : GenericDiffReporter(DiffPrograms::Linux::KDIFF3()) {};
-    };
-
-    class MeldReporter : public GenericDiffReporter {
-    public:
-        MeldReporter() : GenericDiffReporter(DiffPrograms::Linux::MELD()) {};
-    };
-
-    class LinuxDiffReporter : public FirstWorkingReporter
-    {
-    public:
-        LinuxDiffReporter() : FirstWorkingReporter(
-                {
-                        
-                        new MeldReporter(),
-                        new KDiff3Reporter()
-                        
-                }
-        )
-        {
-        }
-    };
-
-}
-
-#endif 
-
- // ******************** From: MacReporters.h
-#ifndef APPROVALTESTS_CPP_MACREPORTERS_H
-#define APPROVALTESTS_CPP_MACREPORTERS_H
-
-
-namespace Mac {
-    class DiffMergeReporter : public GenericDiffReporter {
-    public:
-        DiffMergeReporter() : GenericDiffReporter(DiffPrograms::Mac::DIFF_MERGE()) {}
-    };
-
-    class VisualStudioCodeReporter : public GenericDiffReporter {
-    public:
-        VisualStudioCodeReporter() : GenericDiffReporter(DiffPrograms::Mac::VS_CODE()) {}
-    };
-
-    class BeyondCompareReporter : public GenericDiffReporter {
-    public:
-        BeyondCompareReporter() : GenericDiffReporter(DiffPrograms::Mac::BEYOND_COMPARE()) {}
-    };
-
-    class KaleidoscopeReporter : public GenericDiffReporter {
-    public:
-        KaleidoscopeReporter() : GenericDiffReporter(DiffPrograms::Mac::KALEIDOSCOPE()) {}
-    };
-
-    class KDiff3Reporter : public GenericDiffReporter {
-    public:
-        KDiff3Reporter() : GenericDiffReporter(DiffPrograms::Mac::KDIFF3()) {}
-    };
-
-    class P4MergeReporter : public GenericDiffReporter {
-    public:
-        P4MergeReporter() : GenericDiffReporter(DiffPrograms::Mac::P4MERGE()) {}
-    };
-
-    class TkDiffReporter : public GenericDiffReporter {
-    public:
-        TkDiffReporter() : GenericDiffReporter(DiffPrograms::Mac::TK_DIFF()) {}
-    };
-
-    class MacDiffReporter : public FirstWorkingReporter {
-    public:
-        MacDiffReporter() : FirstWorkingReporter(
-                {
-                        
-                        new BeyondCompareReporter(),
-                        new DiffMergeReporter(),
-                        new KaleidoscopeReporter(),
-                        new P4MergeReporter(),
-                        new KDiff3Reporter(),
-                        new TkDiffReporter(),
-                        new VisualStudioCodeReporter()
-                        
-                }
-        ) {
-        }
-    };
-}
-
-#endif 
-
- // ******************** From: WindowsReporters.h
-#ifndef APPROVALTESTS_CPP_WINDOWSREPORTERS_H
-#define APPROVALTESTS_CPP_WINDOWSREPORTERS_H
-
-
-namespace Windows {
-    class BeyondCompare3Reporter : public GenericDiffReporter {
-    public:
-        BeyondCompare3Reporter() : GenericDiffReporter(DiffPrograms::Windows::BEYOND_COMPARE_3()) {};
-    };
-
-  class VisualStudioCodeReporter : public GenericDiffReporter {
-    public:
-      VisualStudioCodeReporter() : GenericDiffReporter(DiffPrograms::Windows::VS_CODE()) {};
-    };
-
-    class BeyondCompare4Reporter : public GenericDiffReporter {
-    public:
-        BeyondCompare4Reporter() : GenericDiffReporter(DiffPrograms::Windows::BEYOND_COMPARE_4()) {};
-    };
-
-    class BeyondCompareReporter : public FirstWorkingReporter {
-    public:
-        BeyondCompareReporter() : FirstWorkingReporter({new BeyondCompare4Reporter(), new BeyondCompare3Reporter()}) {
-        }
-    };
-
-    class TortoiseImageDiffReporter : public GenericDiffReporter {
-    public:
-        TortoiseImageDiffReporter() : GenericDiffReporter(DiffPrograms::Windows::TORTOISE_IMAGE_DIFF()) {};
-    };
-
-    class TortoiseTextDiffReporter : public GenericDiffReporter {
-    public:
-        TortoiseTextDiffReporter() : GenericDiffReporter(DiffPrograms::Windows::TORTOISE_TEXT_DIFF()) {};
-    };
-
-    class TortoiseDiffReporter : public FirstWorkingReporter {
-    public:
-        TortoiseDiffReporter() : FirstWorkingReporter(
-                {new TortoiseTextDiffReporter(), new TortoiseImageDiffReporter()}) {
-        }
-    };
-
-    class WinMergeReporter : public GenericDiffReporter {
-    public:
-        WinMergeReporter() : GenericDiffReporter(DiffPrograms::Windows::WIN_MERGE_REPORTER()) {};
-    };
-
-    class AraxisMergeReporter : public GenericDiffReporter {
-    public:
-        AraxisMergeReporter() : GenericDiffReporter(DiffPrograms::Windows::ARAXIS_MERGE()) {};
-    };
-
-    class CodeCompareReporter : public GenericDiffReporter {
-    public:
-        CodeCompareReporter() : GenericDiffReporter(DiffPrograms::Windows::CODE_COMPARE()) {};
-    };
-
-    class KDiff3Reporter : public GenericDiffReporter {
-    public:
-        KDiff3Reporter() : GenericDiffReporter(DiffPrograms::Windows::KDIFF3()) {};
-    };
-
-    class WindowsDiffReporter : public FirstWorkingReporter {
-    public:
-        WindowsDiffReporter() : FirstWorkingReporter(
-                {
-                        
-                        new TortoiseDiffReporter(),
-                        new BeyondCompareReporter(),
-                        new WinMergeReporter(),
-                        new AraxisMergeReporter(),
-                        new CodeCompareReporter(),
-                        new KDiff3Reporter(),
-                        new VisualStudioCodeReporter(),
-                        
-                }
-        ) {
-        }
-    };
-}
-
-#endif 
-
- // ******************** From: DiffReporter.h
-#ifndef APPROVALTESTS_CPP_DIFFREPORTER_H
-#define APPROVALTESTS_CPP_DIFFREPORTER_H
-
-
-class DiffReporter : public FirstWorkingReporter
-{
-public:
-    DiffReporter() : FirstWorkingReporter(
-            {
-                    new Mac::MacDiffReporter(),
-                    new Linux::LinuxDiffReporter(),
-                    new Windows::WindowsDiffReporter()
-            }
-    )
-    {
-    }
-};
-
-#endif 
-
- // ******************** From: DefaultReporterFactory.h
-#ifndef APPROVALTESTS_CPP_DEFAULTREPORTERFACTORY_H
-#define APPROVALTESTS_CPP_DEFAULTREPORTERFACTORY_H
-
-
-
-
-class DefaultReporterFactory
-{
-private:
-    using ReporterContainer = std::vector< std::shared_ptr<Reporter> >;
-    APPROVAL_TESTS_MACROS_STATIC(ReporterContainer, defaultReporterContainer, DefaultReporterFactory::createReporterContainer())
-    
-    static ReporterContainer* createReporterContainer()
-    {
-        auto container = new ReporterContainer; 
-        container->push_back( std::make_shared<DiffReporter>());
-        return container;
-    }
-
-public:
-    static std::shared_ptr<Reporter> getDefaultReporter()
-    {
-        return defaultReporterContainer().at(0);
-    }
-    
-    static void setDefaultReporter( const std::shared_ptr<Reporter>& reporter)
-    {
-        defaultReporterContainer().at(0) = reporter;
-    }
-
-};
-
-#endif 
-
- // ******************** From: DefaultReporterDisposer.h
-#ifndef APPROVALTESTS_CPP_DEFAULTREPORTERDISPOSER_H
-#define APPROVALTESTS_CPP_DEFAULTREPORTERDISPOSER_H
-
-
-
-class DefaultReporterDisposer
-{
-private:
-    std::shared_ptr<Reporter> previous_result;
-public:
-    explicit DefaultReporterDisposer(const std::shared_ptr<Reporter>& reporter)
-    {
-        previous_result = DefaultReporterFactory::getDefaultReporter();
-        DefaultReporterFactory::setDefaultReporter(reporter);
-    }
-
-    ~DefaultReporterDisposer()
-    {
-        DefaultReporterFactory::setDefaultReporter(previous_result);
-    }
-};
-
-#endif 
-
- // ******************** From: DefaultReporter.h
-#ifndef APPROVALTESTS_CPP_DEFAULTREPORTER_H
-#define APPROVALTESTS_CPP_DEFAULTREPORTER_H
-
-
-
-class DefaultReporter : public Reporter
-{
-public:
-    virtual bool report(std::string received, std::string approved) const override
-    {
-        return DefaultReporterFactory::getDefaultReporter()->report(received, approved);
-    }
-};
-
-#endif 
-
- // ******************** From: ApprovalNamer.h
-#ifndef APPROVALTESTS_CPP_APPROVALNAMER_H
-#define APPROVALTESTS_CPP_APPROVALNAMER_H
-
-
-using std::string;
-
-class ApprovalNamer
-{
-public:
-    virtual ~ApprovalNamer() = default;
-    virtual string getApprovedFile(string extensionWithDot) = 0;
-    virtual string getReceivedFile(string extensionWithDot) = 0;
-
-};
-
-#endif
-
- // ******************** From: ApprovalTestNamer.h
-#ifndef APPROVALTESTS_CPP_APPROVALTESTNAMER_H
-#define APPROVALTESTS_CPP_APPROVALTESTNAMER_H
-
-
-using std::string;
-
-class TestName {
-public:
-    const string& getFileName() const {
+        checkBuildConfiguration(fileName);
         return fileName;
     }
 
-    void setFileName(const string &file) {
-        fileName = SystemUtils::checkFilenameCase(file);
+    std::string TestName::getOriginalFileName()
+    {
+        return originalFileName;
     }
 
-    std::vector<string> sections;
-private:
-    string fileName;
-};
-
-class TestConfiguration {
-public:
-    std::string subdirectory;
-};
-
-class ApprovalTestNamer : public ApprovalNamer {
-private:
-public:
-    ApprovalTestNamer() {
+    void TestName::setFileName(const std::string& file)
+    {
+        originalFileName = file;
+        fileName = file.empty() ? handleBoostQuirks() : findFileName(file);
     }
 
-    std::string getTestName() const {
+    std::string TestName::findFileName(const std::string& file)
+    {
+        auto newFileName = checkParentDirectoriesForFile(file);
+        return SystemUtils::checkFilenameCase(newFileName);
+    }
+
+    std::string& TestName::rootDirectoryStorage()
+    {
+        // This method is needed to fix static initialisation order
+        static std::string rootDirectory;
+        return rootDirectory;
+    }
+
+    std::string TestName::checkParentDirectoriesForFile(const std::string& file)
+    {
+        auto newFileName = directoryPrefix + file;
+
+        if (!FileUtils::fileExists(newFileName))
+        {
+            // If the build system is Ninja, try looking several levels higher...
+            std::string backOne = ".." + SystemUtils::getDirectorySeparator();
+            std::string prefix;
+            for (int i = 0; i != 10; i++)
+            {
+                prefix += backOne;
+                auto candidateName = prefix + file;
+                if (FileUtils::fileExists(candidateName))
+                {
+                    directoryPrefix = prefix;
+                    return candidateName;
+                }
+            }
+        }
+        return newFileName;
+    }
+
+    bool TestName::registerRootDirectoryFromMainFile(const std::string& file)
+    {
+        std::cout << "TestName::registerRootDirectoryFromMainFile from __FILE__ " << file
+                  << '\n';
+
+        if (file.empty())
+        {
+            throw std::runtime_error("Cannot register an empty path as root directory");
+        }
+
+        std::string adjustedPath = file;
+        std::cout << "TestName::registerRootDirectoryFromMainFile found parent  "
+                  << adjustedPath << '\n';
+
+        rootDirectoryStorage() = FileUtils::getDirectory(adjustedPath);
+        std::cout << "TestName::registerRootDirectoryFromMainFile result        "
+                  << rootDirectoryStorage() << '\n';
+
+        return true;
+    }
+
+    std::string TestName::getRootDirectory()
+    {
+        if (!rootDirectoryStorage().empty())
+        {
+            return rootDirectoryStorage();
+        }
+        else
+        {
+            throw std::runtime_error(HelpMessages::getUnconfiguredRootDirectory());
+        }
+    }
+
+    std::string TestName::handleBoostQuirks() const
+    {
+        return "";
+    }
+
+    void TestName::checkBuildConfiguration(const std::string& fileName)
+    {
+        if (checkBuildConfig_ && !FileUtils::fileExists(fileName))
+        {
+            throw std::runtime_error(getMisconfiguredBuildHelp(fileName));
+        }
+    }
+
+    std::string TestName::getMisconfiguredBuildHelp(const std::string& fileName)
+    {
+        return "\n\n" + HelpMessages::getMisconfiguredBuildHelp(fileName) + "\n\n";
+    }
+
+    std::string ApprovalTestNamer::getTestName() const
+    {
         std::stringstream ext;
         auto test = getCurrentTest();
-        for (size_t i = 0; i < test.sections.size(); i++) {
-            if (0 < i) {
+        for (size_t i = 0; i < test.sections.size(); i++)
+        {
+            if (0 < i)
+            {
                 ext << ".";
             }
             ext << test.sections[i];
@@ -1248,13 +4065,233 @@ public:
         return convertToFileName(ext.str());
     }
 
-    static bool isForbidden(char c)
+    std::string ApprovalTestNamer::convertToFileName(const std::string& fileName)
+    {
+        return FileNameSanitizerFactory::currentSanitizer(fileName);
+    }
+
+    TestName& ApprovalTestNamer::getCurrentTest()
+    {
+        try
+        {
+            return currentTest();
+        }
+        catch (const std::runtime_error&)
+        {
+            std::string helpMessage = getMisconfiguredMainHelp();
+            throw std::runtime_error(helpMessage);
+        }
+    }
+
+    std::string ApprovalTestNamer::getMisconfiguredMainHelp()
+    {
+        return "\n\n" + HelpMessages::getMisconfiguredMainHelp() + "\n\n";
+    }
+
+    std::string ApprovalTestNamer::getFileName() const
+    {
+        return getSourceFileName();
+    }
+
+    std::string ApprovalTestNamer::getSourceFileName() const
+    {
+        auto file = getCurrentTest().getFileName();
+        auto start = file.rfind(SystemUtils::getDirectorySeparator()) + 1;
+        auto end = file.rfind('.');
+        auto fileName = file.substr(start, end - start);
+        return convertToFileName(fileName);
+    }
+
+    std::string ApprovalTestNamer::getTestSourceDirectory() const
+    {
+        auto file = getCurrentTest().getFileName();
+        return FileUtils::getDirectory(file);
+    }
+
+    std::string ApprovalTestNamer::getRelativeTestSourceDirectory() const
+    {
+        // We are using the original directory - as obtained from __FILE__,
+        // as this seems to be consistent for relative paths, regardless of
+        // Ninja __FILE__ quirks
+        auto originalDir =
+            FileUtils::getDirectory(getCurrentTest().getOriginalFileName());
+        originalDir =
+            StringUtils::replaceAll(originalDir, TestName::getRootDirectory(), "");
+        return originalDir;
+    }
+
+    std::string ApprovalTestNamer::getApprovalsSubdirectory() const
+    {
+        std::string sub_directory;
+        if (!testConfiguration().subdirectory.empty())
+        {
+            sub_directory =
+                testConfiguration().subdirectory + SystemUtils::getDirectorySeparator();
+        }
+        return sub_directory;
+    }
+
+    std::string ApprovalTestNamer::getDirectory() const
+    {
+        std::string directory = getTestSourceDirectory();
+        std::string sub_directory = getApprovalsSubdirectory();
+        directory += sub_directory;
+        SystemUtils::ensureDirectoryExists(directory);
+        return directory;
+    }
+
+    TestName& ApprovalTestNamer::currentTest(TestName* value)
+    {
+        static TestName* staticValue;
+        if (value != nullptr)
+        {
+            staticValue = value;
+        }
+        if (staticValue == nullptr)
+        {
+            throw std::runtime_error("The variable in currentTest() is not initialised");
+        }
+        return *staticValue;
+    }
+
+    TestConfiguration& ApprovalTestNamer::testConfiguration()
+    {
+        static TestConfiguration configuration;
+        return configuration;
+    }
+
+    std::string ApprovalTestNamer::getApprovedFile(std::string extensionWithDot) const
+    {
+
+        return getFullFileName(".approved", extensionWithDot);
+    }
+
+    std::string ApprovalTestNamer::getReceivedFile(std::string extensionWithDot) const
+    {
+
+        return getFullFileName(".received", extensionWithDot);
+    }
+
+    std::string ApprovalTestNamer::getOutputFileBaseName() const
+    {
+        return getSourceFileName() + "." + getTestName();
+    }
+
+    std::string
+    ApprovalTestNamer::getFullFileName(const std::string& approved,
+                                       const std::string& extensionWithDot) const
+    {
+        std::stringstream ext;
+        ext << getDirectory() << getOutputFileBaseName() << approved << extensionWithDot;
+        return ext.str();
+    }
+
+    bool ApprovalTestNamer::setCheckBuildConfig(bool enabled)
+    {
+        auto previous = TestName::checkBuildConfig_;
+        TestName::checkBuildConfig_ = enabled;
+        return previous;
+    }
+}
+
+// ******************** From: DefaultNamerDisposer.cpp
+
+namespace ApprovalTests
+{
+    DefaultNamerDisposer::DefaultNamerDisposer(NamerCreator namerCreator)
+    {
+        previous_result = DefaultNamerFactory::getDefaultNamer();
+        DefaultNamerFactory::setDefaultNamer(std::move(namerCreator));
+    }
+
+    DefaultNamerDisposer::~DefaultNamerDisposer()
+    {
+        DefaultNamerFactory::setDefaultNamer(previous_result);
+    }
+}
+
+// ******************** From: DefaultNamerFactory.cpp
+
+namespace ApprovalTests
+{
+    NamerCreator& DefaultNamerFactory::defaultNamer()
+    {
+        static NamerCreator namer = []() {
+            return std::make_shared<ApprovalTestNamer>();
+        };
+        return namer;
+    }
+
+    NamerCreator DefaultNamerFactory::getDefaultNamer()
+    {
+        return defaultNamer();
+    }
+
+    void DefaultNamerFactory::setDefaultNamer(NamerCreator namer)
+    {
+        defaultNamer() = std::move(namer);
+    }
+}
+
+// ******************** From: ExistingFileNamer.cpp
+
+namespace ApprovalTests
+{
+    ExistingFileNamer::ExistingFileNamer(std::string filePath_, const Options& options)
+        : filePath(std::move(filePath_)), options_(options)
+    {
+    }
+
+    ExistingFileNamer::ExistingFileNamer(const ExistingFileNamer& x)
+        : filePath(x.filePath), options_(x.options_)
+    {
+    }
+
+    ExistingFileNamer::ExistingFileNamer(ExistingFileNamer&& x) noexcept
+        : filePath(std::move(x.filePath)), options_(x.options_)
+    {
+    }
+
+    std::string ExistingFileNamer::getApprovedFile(std::string extensionWithDot) const
+    {
+        return options_.getNamer()->getApprovedFile(extensionWithDot);
+    }
+
+    std::string ExistingFileNamer::getReceivedFile(std::string) const
+    {
+        return filePath;
+    }
+}
+
+// ******************** From: FileNameSanitizerDisposer.cpp
+#include <sstream>
+
+namespace ApprovalTests
+{
+
+    FileNameSanitizerDisposer::FileNameSanitizerDisposer(FileNameSanitizer sanitizer)
+    {
+        previous_result = std::move(FileNameSanitizerFactory::currentSanitizer);
+        FileNameSanitizerFactory::currentSanitizer = std::move(sanitizer);
+    }
+
+    FileNameSanitizerDisposer::~FileNameSanitizerDisposer()
+    {
+        FileNameSanitizerFactory::currentSanitizer = std::move(previous_result);
+    }
+}
+
+// ******************** From: FileNameSanitizerFactory.cpp
+#include <sstream>
+namespace ApprovalTests
+{
+    bool FileNameSanitizerFactory::isForbidden(char c)
     {
         static std::string forbiddenChars("\\/:?\"<>|' ");
         return std::string::npos != forbiddenChars.find(c);
     }
 
-    static string convertToFileName(const string& fileName)
+    std::string FileNameSanitizerFactory::defaultSanitizer(std::string fileName)
     {
         std::stringstream result;
         for (auto ch : fileName)
@@ -1271,1205 +4308,343 @@ public:
         return result.str();
     }
 
-// <SingleHpp unalterable>
-    static TestName &getCurrentTest()
+    FileNameSanitizer FileNameSanitizerFactory::currentSanitizer =
+        FileNameSanitizerFactory::defaultSanitizer;
+
+}
+
+// ******************** From: HelpMessages.cpp
+
+#include <sstream>
+
+namespace ApprovalTests
+{
+
+    std::string HelpMessages::getMisconfiguredBuildHelp(const std::string& fileName)
     {
-        try
-        {
-            return currentTest();
-        }
-        catch( const std::runtime_error& )
-        {
-            std::string lineBreak = "************************************************************************************n";
-            std::string lineBuffer = "*                                                                                  *n";
-            std::string helpMessage =
-                "nn" + lineBreak + lineBuffer + 
-R"(* Welcome to Approval Tests.
-* 
+        std::string helpMessage = R"(* Welcome to Approval Tests.
+*
+* There seems to be a problem with your build configuration.
+* We cannot find the test source file at:
+*   [fileName]
+*
+* For details on how to fix this, please visit:
+* https://github.com/approvals/ApprovalTests.cpp/blob/master/doc/TroubleshootingMisconfiguredBuild.md
+*
+* For advanced users only:
+* If you believe you have reached this message in error, you can bypass
+* the check by calling ApprovalTestNamer::setCheckBuildConfig(false);
+)";
+        return StringUtils::replaceAll(
+            topAndTailHelpMessage(helpMessage), "[fileName]", fileName);
+    }
+
+    std::string HelpMessages::getMisconfiguredMainHelp()
+    {
+        std::string helpMessage = R"(* Welcome to Approval Tests.
+*
 * You have forgotten to configure your test framework for Approval Tests.
-* 
+*
 * To do this in Catch, add the following to your main.cpp:
-* 
+*
 *     #define APPROVALS_CATCH
 *     #include "ApprovalTests.hpp"
-* 
+*
 * To do this in Google Test, add the following to your main.cpp:
-* 
+*
 *     #define APPROVALS_GOOGLETEST
 *     #include "ApprovalTests.hpp"
-* 
+*
 * To do this in doctest, add the following to your main.cpp:
-* 
+*
 *     #define APPROVALS_DOCTEST
 *     #include "ApprovalTests.hpp"
-* 
+*
+* To do this in Boost.Test, add the following to your main.cpp:
+*
+*     #define APPROVALS_BOOSTTEST
+*     #include "ApprovalTests.hpp"
+*
+* To do this in CppUTest, add the following to your main.cpp:
+*
+*     #define APPROVALS_CPPUTEST
+*     #include "ApprovalTests.hpp"
+*
+* To do this in [Boost].UT, add the following to your main.cpp:
+*
+*     #define APPROVALS_UT
+*     #include "ApprovalTests.hpp"
+*
 * For more information, please visit:
-* https://github.com/approvals/ApprovalTests.cpp/blob/master/doc/GettingStarted.md
-)" +
-                    lineBuffer + lineBreak + 'n';
-            throw std::runtime_error( helpMessage );
-        }
-    }
-// </SingleHpp>
-
-
-    
-    string getFileName() {
-        return getSourceFileName();
+* https://github.com/approvals/ApprovalTests.cpp/blob/master/doc/TroubleshootingMisconfiguredMain.md
+)";
+        return topAndTailHelpMessage(helpMessage);
     }
 
-
-    std::string getSourceFileName() const {
-        auto file = getCurrentTest().getFileName();
-        auto start = file.rfind(SystemUtils::getDirectorySeparator()) + 1;
-        auto end = file.rfind(".");
-        auto fileName = file.substr(start, end - start);
-        return convertToFileName(fileName);
+    std::string HelpMessages::getUnconfiguredRootDirectory()
+    {
+        std::string helpMessage = R"(* Hello from Approval Tests.
+*
+* It looks like your program is calling some code that requires knowledge of
+* the location of the main() in your source tree.
+*
+* To do this, add the following to your main.cpp file:
+*
+*     APPROVAL_TESTS_REGISTER_MAIN_DIRECTORY
+*
+* Currently, this is only required if you are using TemplatedCustomNamer's
+* {RelativeTestSourceDirectory}.
+)";
+        return topAndTailHelpMessage(helpMessage);
     }
 
-    string getDirectory() {
-        auto file = getCurrentTest().getFileName();
-        auto end = file.rfind(SystemUtils::getDirectorySeparator()) + 1;
-        auto directory = file.substr(0, end);
-        if ( ! testConfiguration().subdirectory.empty() )
+    std::string
+    HelpMessages::getUnknownEnvVarReporterHelp(const std::string& envVarName,
+                                               const std::string& selected,
+                                               const std::vector<std::string>& knowns)
+    {
+        std::string helpMessage =
+            R"(* The environment variable [envVarName] contains the value
+* [selected]
+*
+* This reporter is not recognised.
+*
+* Please unset the environment value, or change it to refer to one of the
+* known reporters:
+*
+[known]*
+* For more information, see:
+* https://github.com/approvals/ApprovalTests.cpp/blob/master/doc/how_tos/SelectReporterWithEnvironmentVariable.md
+)";
+
+        return envVarErrorMessage(envVarName, selected, knowns, helpMessage);
+    }
+
+    std::string
+    HelpMessages::getInvalidEnvVarReporterHelp(const std::string& envVarName,
+                                               const std::string& selected,
+                                               const std::vector<std::string>& knowns)
+    {
+        std::string helpMessage =
+            R"(* The environment variable [envVarName] contains the value
+* [selected]
+*
+* This reporter is recognised, but cannot be found on this machine.
+*
+* Please unset the environment value, or change it to refer to a working
+* reporter:
+*
+[known]*
+* For more information, see:
+* https://github.com/approvals/ApprovalTests.cpp/blob/master/doc/how_tos/SelectReporterWithEnvironmentVariable.md
+)";
+
+        return envVarErrorMessage(envVarName, selected, knowns, helpMessage);
+    }
+
+    std::string HelpMessages::envVarErrorMessage(const std::string& envVarName,
+                                                 const std::string& selected,
+                                                 const std::vector<std::string>& knowns,
+                                                 std::string& helpMessage)
+    {
+        std::stringstream ss;
+        for (auto& known : knowns)
         {
-            directory += testConfiguration().subdirectory + SystemUtils::getDirectorySeparator(); 
-            SystemUtils::ensureDirectoryExists(directory);
+            ss << "* " << known << '\n';
         }
-        return directory;
+        helpMessage = StringUtils::replaceAll(helpMessage, "[selected]", selected);
+        helpMessage = StringUtils::replaceAll(helpMessage, "[envVarName]", envVarName);
+        return topAndTailHelpMessage(
+            StringUtils::replaceAll(helpMessage, "[known]", ss.str()));
     }
 
-    APPROVAL_TESTS_MACROS_STATIC(TestName, currentTest, NULL)
-    APPROVAL_TESTS_MACROS_STATIC(TestConfiguration, testConfiguration, new TestConfiguration)
-
-    virtual string getApprovedFile(string extensionWithDot) {
-
-        return getFullFileName(".approved", extensionWithDot);
+    std::string HelpMessages::topAndTailHelpMessage(const std::string& message)
+    {
+        const std::string lineBreak =
+            "**************************************************************"
+            "***************";
+        const std::string lineBuffer =
+            "*                                                             "
+            "              *\n";
+        return lineBreak + '\n' + lineBuffer + message + lineBuffer + lineBreak;
     }
+}
 
-    virtual string getReceivedFile(string extensionWithDot) {
+// ******************** From: NamerFactory.cpp
 
-        return getFullFileName(".received", extensionWithDot);
-    }
-
-    std::string getOutputFileBaseName() const {
-        return getSourceFileName() + "." + getTestName();
-    }
-
-    std::string getFullFileName(string approved, string extensionWithDot) {
-        std::stringstream ext;
-        ext << getDirectory() << getOutputFileBaseName() << approved << extensionWithDot;
-        return ext.str();
-    }
-};
-
-#endif
-
- // ******************** From: SubdirectoryDisposer.h
-#ifndef APPROVALTESTS_CPP_SUBDIRECTORYDISPOSER_H
-#define APPROVALTESTS_CPP_SUBDIRECTORYDISPOSER_H
-
-
-
-
-class SubdirectoryDisposer
+namespace ApprovalTests
 {
-private:
-    std::string previous_result;
-public:
-    explicit SubdirectoryDisposer(std::string subdirectory)
+    SectionNameDisposer
+    NamerFactory::appendToOutputFilename(const std::string& sectionName)
+    {
+        return SectionNameDisposer(ApprovalTestNamer::currentTest(), sectionName);
+    }
+}
+
+// ******************** From: SectionNameDisposer.cpp
+
+namespace ApprovalTests
+{
+    SectionNameDisposer::SectionNameDisposer(TestName& currentTest_,
+                                             const std::string& scope_name)
+        : currentTest(currentTest_)
+    {
+        // Add extra section to output filename, to allow multiple files
+        // to verified from a single test:
+        currentTest_.sections.push_back(scope_name);
+    }
+
+    SectionNameDisposer::~SectionNameDisposer()
+    {
+        // Remove the extra section we added in the constructor
+        currentTest.sections.pop_back();
+    }
+}
+
+// ******************** From: SeparateApprovedAndReceivedDirectoriesNamer.cpp
+
+namespace ApprovalTests
+{
+    std::string separateDirectoryPath()
+    {
+        // clang-format off
+        auto path = "{TestSourceDirectory}/{ApprovalsSubdirectory}/{ApprovedOrReceived}/{TestFileName}.{TestCaseName}.{FileExtension}";
+        // clang-format on
+        return path;
+    }
+
+    SeparateApprovedAndReceivedDirectoriesNamer::
+        SeparateApprovedAndReceivedDirectoriesNamer()
+        : TemplatedCustomNamer(separateDirectoryPath())
+    {
+    }
+
+    DefaultNamerDisposer SeparateApprovedAndReceivedDirectoriesNamer::useAsDefaultNamer()
+    {
+        return Approvals::useAsDefaultNamer([]() {
+            return std::make_shared<SeparateApprovedAndReceivedDirectoriesNamer>();
+        });
+    }
+}
+
+// ******************** From: SubdirectoryDisposer.cpp
+
+namespace ApprovalTests
+{
+    SubdirectoryDisposer::SubdirectoryDisposer(std::string subdirectory)
     {
         previous_result = ApprovalTestNamer::testConfiguration().subdirectory;
-        ApprovalTestNamer::testConfiguration().subdirectory = subdirectory;
+        ApprovalTestNamer::testConfiguration().subdirectory = std::move(subdirectory);
     }
 
-    ~SubdirectoryDisposer()
+    SubdirectoryDisposer::~SubdirectoryDisposer()
     {
         ApprovalTestNamer::testConfiguration().subdirectory = previous_result;
     }
-};
-
-#endif 
-
- // ******************** From: ExistingFileNamer.h
-#ifndef APPROVALTESTS_CPP_EXISTINGFILENAMER_H
-#define APPROVALTESTS_CPP_EXISTINGFILENAMER_H
-
-
-class ExistingFileNamer: public ApprovalNamer{
-    ApprovalTestNamer namer;
-    std::string filePath;
-public:
-    ExistingFileNamer(std::string filePath): filePath(filePath){
-
-    }
-    virtual string getApprovedFile(string extensionWithDot) {
-        return namer.getApprovedFile(extensionWithDot);
-    }
-    virtual string getReceivedFile(string ) {
-        return filePath;
-    }
-
-};
-
-#endif 
-
- // ******************** From: DefaultFrontLoadedReporter.h
-#ifndef APPROVALTESTS_CPP_DEFAULTFRONTLOADEDREPORTER_H
-#define APPROVALTESTS_CPP_DEFAULTFRONTLOADEDREPORTER_H
-
-
-
-class DefaultFrontLoadedReporter : public Reporter
-{
-public:
-    virtual bool report(std::string , std::string ) const override
-    {
-        return false;
-    }
-};
-
-#endif 
-
- // ******************** From: FrontLoadedReporterFactory.h
-#ifndef APPROVALTESTS_CPP_FRONTLOADEDREPORTERFACTORY_H
-#define APPROVALTESTS_CPP_FRONTLOADEDREPORTERFACTORY_H
-
-
-
-
-class FrontLoadedReporterFactory
-{
-    using ReporterContainer = std::vector< std::shared_ptr<Reporter> >;
-    APPROVAL_TESTS_MACROS_STATIC(ReporterContainer, frontLoadedReporterContainer, FrontLoadedReporterFactory::createReporterContainer())
-
-    static ReporterContainer* createReporterContainer()
-    {
-        auto container = new ReporterContainer;
-        container->push_back( std::make_shared<DefaultFrontLoadedReporter>());
-        return container;
-    }
-
-public:
-    static std::shared_ptr<Reporter> getFrontLoadedReporter()
-    {
-        return frontLoadedReporterContainer().at(0);
-    }
-
-    static void setFrontLoadedReporter( const std::shared_ptr<Reporter>& reporter)
-    {
-        frontLoadedReporterContainer().at(0) = reporter;
-    }
-};
-
-#endif 
-
- // ******************** From: FrontLoadedReporterDisposer.h
-#ifndef APPROVALTESTS_CPP_FRONTLOADEDREPORTERDISPOSER_H
-#define APPROVALTESTS_CPP_FRONTLOADEDREPORTERDISPOSER_H
-
-
-
-class FrontLoadedReporterDisposer
-{
-private:
-    std::shared_ptr<Reporter> previous_result;
-public:
-    explicit FrontLoadedReporterDisposer(const std::shared_ptr<Reporter>& reporter)
-    {
-        previous_result = FrontLoadedReporterFactory::getFrontLoadedReporter();
-        FrontLoadedReporterFactory::setFrontLoadedReporter(reporter);
-    }
-
-    ~FrontLoadedReporterDisposer()
-    {
-        FrontLoadedReporterFactory::setFrontLoadedReporter(previous_result);
-    }
-
-};
-
-
-#endif 
-
- // ******************** From: ApprovalComparator.h
-#ifndef APPROVALTESTS_CPP_APPROVALCOMPARATOR_H
-#define APPROVALTESTS_CPP_APPROVALCOMPARATOR_H
-
-
-class ApprovalComparator
-{
-public:
-    virtual ~ApprovalComparator() = default;
-
-    virtual bool contentsAreEquivalent(std::string receivedPath,
-                                       std::string approvedPath) const = 0;
-};
-
-#endif 
-
- // ******************** From: TextFileComparator.h
-#ifndef APPROVALTESTS_CPP_TEXTFILECOMPARATOR_H
-#define APPROVALTESTS_CPP_TEXTFILECOMPARATOR_H
-
-
-class TextFileComparator : public ApprovalComparator
-{
-public:
-    static std::ifstream::int_type getNextRelevantCharacter(std::ifstream& astream)
-    {
-        auto ch = astream.get();
-        if (ch == '\r')
-        {
-            return astream.get();
-        }
-        else
-        {
-            return ch;
-        }
-    }
-
-    virtual bool contentsAreEquivalent(std::string receivedPath,
-                                       std::string approvedPath) const
-    {
-        std::ifstream astream(approvedPath.c_str(),
-                              std::ios::binary | std::ifstream::in);
-        std::ifstream rstream(receivedPath.c_str(),
-                              std::ios::binary | std::ifstream::in);
-
-        while (astream.good() && rstream.good()) {
-            int a = getNextRelevantCharacter(astream);
-            int r = getNextRelevantCharacter(rstream);
-
-            if (a != r) {
-                return false;
-            }
-        }
-        return true;
-    }
-};
-#endif 
-
- // ******************** From: ApprovalException.h
-#ifndef APPROVALTESTS_CPP_APPROVALEXCEPTION_H
-#define APPROVALTESTS_CPP_APPROVALEXCEPTION_H
-
-
-class ApprovalException : public std::exception
-{
-private:
-    std::string message;
-public:
-    ApprovalException( const std::string& msg ) : message( msg ) {}
-
-    virtual const char *what() const throw()
-    {
-        return message.c_str();
-    }
-};
-
-class ApprovalMismatchException : public ApprovalException
-{
-private:
-    std::string format( const std::string &received, const std::string &approved )
-    {
-        std::stringstream s;
-        s << "Failed Approval: \n"
-          << "Received does not match approved \n"
-          << "Received : \"" << received << "\" \n"
-          << "Approved : \"" << approved << "\"";
-        return s.str();
-    }
-public:
-    ApprovalMismatchException( std::string received, std::string approved )
-        : ApprovalException( format( received, approved ) )
-    {
-    }
-};
-
-class ApprovalMissingException : public ApprovalException
-{
-private:
-    std::string format( const std::string &file )
-    {
-        std::stringstream s;
-        s << "Failed Approval: \n"
-          << "Approval File Not Found \n"
-          << "File: \"" << file << '"';
-        return s.str();
-    }
-public:
-    ApprovalMissingException( std::string , std::string approved )
-        : ApprovalException( format( approved ) )
-    {
-    }
-};
-
-#endif
-
- // ******************** From: FileApprover.h
-#ifndef APPROVALTESTS_CPP_FILEAPPROVER_H
-#define APPROVALTESTS_CPP_FILEAPPROVER_H
-
-
-class FileApprover {
-private:
-    using ComparatorContainer = std::map< std::string, std::shared_ptr<ApprovalComparator> >;
-    APPROVAL_TESTS_MACROS_STATIC(ComparatorContainer, comparators, new ComparatorContainer())
-
-public:
-    FileApprover() {};
-
-    ~FileApprover() {};
-
-    static void registerComparator(std::string extensionWithDot, std::shared_ptr<ApprovalComparator> comparator)
-    {
-        comparators()[extensionWithDot] = comparator;
-    }
-
-    static std::shared_ptr<ApprovalComparator> getComparatorForFile(string receivedPath) {
-        const std::string fileExtension = FileUtils::getExtensionWithDot(receivedPath);
-        auto iterator = comparators().find(fileExtension);
-        if (iterator != comparators().end()) {
-            return iterator->second;
-        }
-        return std::make_shared<TextFileComparator>();
-    }
-
-    
-    static void verify(std::string receivedPath,
-                       std::string approvedPath,
-                       const ApprovalComparator& comparator) {
-        if (!FileUtils::fileExists(approvedPath)) {
-            throw ApprovalMissingException(receivedPath, approvedPath);
-        }
-
-        if (!FileUtils::fileExists(receivedPath)) {
-            throw ApprovalMissingException(approvedPath, receivedPath);
-        }
-
-        if (!comparator.contentsAreEquivalent(receivedPath, approvedPath)) {
-            throw ApprovalMismatchException(receivedPath, approvedPath);
-        }
-    }
-
-    static void verify(std::string receivedPath,
-                       std::string approvedPath) {
-        verify(receivedPath, approvedPath, *getComparatorForFile(receivedPath));
-    }
-
-    static void verify(ApprovalNamer& n, ApprovalWriter& s, const Reporter& r) {
-        std::string approvedPath = n.getApprovedFile(s.getFileExtensionWithDot());
-        std::string receivedPath = n.getReceivedFile(s.getFileExtensionWithDot());
-        s.write(receivedPath);
-        try
-        {
-            verify(receivedPath, approvedPath);
-            s.cleanUpReceived(receivedPath);
-        }
-        catch (const ApprovalException&) {
-            reportAfterTryingFrontLoadedReporter(receivedPath, approvedPath, r);
-            throw;
-        }
-    }
-
-    static void
-    reportAfterTryingFrontLoadedReporter(const string &receivedPath, const string &approvedPath, const Reporter &r)
-    {
-        auto tryFirst = FrontLoadedReporterFactory::getFrontLoadedReporter();
-        if (!tryFirst->report(receivedPath, approvedPath))
-        {
-            r.report(receivedPath, approvedPath);
-        }
-    }
-
-
-};
-
-#endif
-
- // ******************** From: Approvals.h
-#ifndef APPROVALTESTS_CPP_APPROVALS_H
-#define APPROVALTESTS_CPP_APPROVALS_H
-
-
-class Approvals {
-private:
-    Approvals() {}
-
-    ~Approvals() {}
-
-public:
-    static std::shared_ptr<ApprovalNamer> getDefaultNamer()
-    {
-        return std::make_shared<ApprovalTestNamer>();
-    }
-
-    static void verify(std::string contents, const Reporter &reporter = DefaultReporter()) {
-        StringWriter writer(contents);
-        ApprovalTestNamer namer;
-        FileApprover::verify(namer, writer, reporter);
-    }
-
-    template<typename T>
-    static void verify(const T& contents, const Reporter &reporter = DefaultReporter()) {
-        verify(StringUtils::toString(contents), reporter);
-    }
-
-    template<typename T>
-    static void verify(const T& contents,
-                       std::function<void(const T&, std::ostream &)> converter,
-                       const Reporter &reporter = DefaultReporter())
-    {
-        std::stringstream s;
-        converter(contents, s);
-        verify(s.str(), reporter);
-    }
-
-    static void verifyExceptionMessage(
-        std::function<void(void)> functionThatThrows,
-        const Reporter &reporter = DefaultReporter())
-    {
-        std::string message = "*** no exception thrown ***";
-        try
-        {
-            functionThatThrows();
-        }
-        catch(const std::exception& e)
-        {
-            message = e.what();
-        }
-        Approvals::verify(message, reporter);
-    }
-    
-    template<typename Iterator>
-    static void verifyAll(std::string header,
-                          const Iterator &start, const Iterator &finish,
-                          std::function<void(typename Iterator::value_type, std::ostream &)> converter,
-                          const Reporter &reporter = DefaultReporter()) {
-        std::stringstream s;
-        if (!header.empty()) {
-            s << header << "\n\n\n";
-        }
-        for (auto it = start; it != finish; ++it) {
-            converter(*it, s);
-            s << '\n';
-        }
-        verify(s.str(), reporter);
-    }
-
-    template<typename Container>
-    static void verifyAll(std::string header,
-                          const Container &list,
-                          std::function<void(typename Container::value_type, std::ostream &)> converter,
-                          const Reporter &reporter = DefaultReporter()) {
-        verifyAll<typename Container::const_iterator>(header, list.begin(), list.end(), converter, reporter);
-    }
-
-    template<typename T>
-    static void verifyAll(std::string header,
-                          const std::vector<T> &list,
-                          const Reporter &reporter = DefaultReporter()) {
-        int i = 0;
-        verifyAll<std::vector<T>>(header, list, [&](T e, std::ostream &s) { s << "[" << i++ << "] = " << e; },
-                                  reporter);
-    }
-
-    template<typename T>
-    static void verifyAll(const std::vector<T> &list,
-                          const Reporter &reporter = DefaultReporter()) {
-        verifyAll<T>("", list, reporter);
-    }
-
-    static void verifyExistingFile(const std::string filePath, const Reporter &reporter = DefaultReporter()) {
-        ExistingFile writer(filePath);
-        ExistingFileNamer namer(filePath);
-        FileApprover::verify(namer, writer, reporter);
-    }
-    
-    static SubdirectoryDisposer useApprovalsSubdirectory(std::string subdirectory = "approval_tests")
-    {
-        return SubdirectoryDisposer(subdirectory);
-    }
-
-    static DefaultReporterDisposer useAsDefaultReporter(const std::shared_ptr<Reporter>& reporter)
-    {
-        return DefaultReporterDisposer(reporter);
-    }
-
-    static FrontLoadedReporterDisposer useAsFrontLoadedReporter(const std::shared_ptr<Reporter>& reporter)
-    {
-        return FrontLoadedReporterDisposer(reporter);
-    }
-
-};
-
-#endif
-
- // ******************** From: Catch2Approvals.h
-
-#ifndef APPROVALTESTS_CPP_CATCH2APPROVALS_H
-#define APPROVALTESTS_CPP_CATCH2APPROVALS_H
-
-
-// <SingleHpp unalterable>
-#ifdef APPROVALS_CATCH
-#define CATCH_CONFIG_MAIN
-
-#include <Catch.hpp>
-
-struct Catch2ApprovalListener : Catch::TestEventListenerBase {
-    using TestEventListenerBase::TestEventListenerBase;
-    TestName currentTest;
-
-    Catch2ApprovalListener(Catch::ReporterConfig const &_config) : Catch::TestEventListenerBase(_config) {}
-
-    virtual void testCaseStarting(Catch::TestCaseInfo const &testInfo) override {
-
-        currentTest.setFileName(testInfo.lineInfo.file);
-        ApprovalTestNamer::currentTest(&currentTest);
-    }
-
-    virtual void testCaseEnded(Catch::TestCaseStats const &/*testCaseStats*/) override {
-        while (!currentTest.sections.empty()) {
-            currentTest.sections.pop_back();
-        }
-    }
-
-    virtual void sectionStarting(Catch::SectionInfo const &sectionInfo) override {
-        currentTest.sections.push_back(sectionInfo.name);
-    }
-
-    virtual void sectionEnded(Catch::SectionStats const &/*sectionStats*/) override {
-        currentTest.sections.pop_back();
-    }
-};
-CATCH_REGISTER_LISTENER(Catch2ApprovalListener)
-
-#endif
-#ifdef TEST_COMMIT_REVERT_CATCH
-
-struct Catch2TestCommitRevert : Catch::TestEventListenerBase {
-    using TestEventListenerBase::TestEventListenerBase;
-    virtual void  testRunEnded( Catch::TestRunStats const& testRunStats )override{
-        bool commit = testRunStats.totals.testCases.allOk();
-        std::string message = "r ";
-        if (commit) {
-            std::cout << "git add -A n";
-            std::cout << "git commit -m " << message;
-        } else
-        {
-            std::cout << "git clean -fd n";
-            std::cout << "git reset --hard HEAD n";
-        }
-    }
-};
-CATCH_REGISTER_LISTENER(Catch2TestCommitRevert)
-#endif
-// </SingleHpp>
-#endif 
-
- // ******************** From: CombinationApprovals.h
-#ifndef APPROVALTESTS_CPP_COMBINATIONAPPROVALS_H
-#define APPROVALTESTS_CPP_COMBINATIONAPPROVALS_H
-
-
-class Empty
-{
-public:
-    template< typename Other>
-    bool operator!=(const Other &) const {
-        return true;
-    }
-
-    bool operator!=(const Empty &) const {
-        return false;
-    }
-
-    friend std::ostream &operator<<(std::ostream &os, const Empty&) {
-        os << "This should never be written - see Empty\n";
-        return os;
-    }
-
-};
-
-class CombinationApprovals
-{
-public:
-    CombinationApprovals() = delete;
-    ~CombinationApprovals() = delete;
-
-    template <
-        typename Function,
-        typename Container1,
-        typename Container2,
-        typename Container3,
-        typename Container4,
-        typename Container5,
-        typename Container6,
-        typename Container7,
-        typename Container8,
-        typename Container9,
-        
-        typename std::enable_if<! std::is_base_of<Reporter, Container9>::value, int>::type = 0>
-    static void verifyAllCombinations(
-        Function converter,
-        const Container1& inputs1,
-        const Container2& inputs2,
-        const Container3& inputs3,
-        const Container4& inputs4,
-        const Container5& inputs5,
-        const Container6& inputs6,
-        const Container7& inputs7,
-        const Container8& inputs8,
-        const Container9& inputs9,
-        const Reporter& reporter = DefaultReporter())
-    {
-        Empty empty;
-        std::stringstream s;
-        for (auto input1 : inputs1)
-        {
-            for (auto input2 : inputs2)
-            {
-                for (auto input3 : inputs3)
-                {
-                    for (auto input4 : inputs4)
-                    {
-                        for (auto input5 : inputs5)
-                        {
-                            for (auto input6 : inputs6)
-                            {
-                                for (auto input7 : inputs7)
-                                {
-                                    for (auto input8 : inputs8)
-                                    {
-                                        for (auto input9 : inputs9)
-                                        {
-                                            s << "(" << input1;
-                                            if (empty != input2) { s << ", " << input2; }
-                                            if (empty != input3) { s << ", " << input3; }
-                                            if (empty != input4) { s << ", " << input4; }
-                                            if (empty != input5) { s << ", " << input5; }
-                                            if (empty != input6) { s << ", " << input6; }
-                                            if (empty != input7) { s << ", " << input7; }
-                                            if (empty != input8) { s << ", " << input8; }
-                                            if (empty != input9) { s << ", " << input9; }
-                                            s << ") => " << converter(input1, input2, input3, input4, input5,
-                                                                      input6, input7, input8, input9) << '\n';
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        Approvals::verify(s.str(), reporter);
-    }
-
-    template <
-        typename Function,
-        typename Container1,
-        typename Container2,
-        typename Container3,
-        typename Container4,
-        typename Container5,
-        typename Container6,
-        typename Container7,
-        typename Container8,
-        
-        typename std::enable_if<! std::is_base_of<Reporter, Container8>::value, int>::type = 0>
-    static void verifyAllCombinations(
-        Function converter,
-        const Container1& inputs1,
-        const Container2& inputs2,
-        const Container3& inputs3,
-        const Container4& inputs4,
-        const Container5& inputs5,
-        const Container6& inputs6,
-        const Container7& inputs7,
-        const Container8& inputs8,
-        const Reporter& reporter = DefaultReporter())
-    {
-        verifyAllCombinations(
-            [&](typename Container1::value_type i1,
-                typename Container2::value_type i2,
-                typename Container3::value_type i3,
-                typename Container4::value_type i4,
-                typename Container5::value_type i5,
-                typename Container6::value_type i6,
-                typename Container7::value_type i7,
-                typename Container8::value_type i8,
-                Empty){return converter(i1, i2, i3, i4, i5, i6, i7, i8);},
-            inputs1,
-            inputs2,
-            inputs3,
-            inputs4,
-            inputs5,
-            inputs6,
-            inputs7,
-            inputs8,
-            empty(),
-            reporter);
-    }
-
-    template <
-        typename Function,
-        typename Container1,
-        typename Container2,
-        typename Container3,
-        typename Container4,
-        typename Container5,
-        typename Container6,
-        typename Container7,
-        
-        typename std::enable_if<! std::is_base_of<Reporter, Container7>::value, int>::type = 0>
-    static void verifyAllCombinations(
-        Function converter,
-        const Container1& inputs1,
-        const Container2& inputs2,
-        const Container3& inputs3,
-        const Container4& inputs4,
-        const Container5& inputs5,
-        const Container6& inputs6,
-        const Container7& inputs7,
-        const Reporter& reporter = DefaultReporter())
-    {
-        verifyAllCombinations(
-            [&](typename Container1::value_type i1,
-                typename Container2::value_type i2,
-                typename Container3::value_type i3,
-                typename Container4::value_type i4,
-                typename Container5::value_type i5,
-                typename Container6::value_type i6,
-                typename Container7::value_type i7,
-                Empty){return converter(i1, i2, i3, i4, i5, i6, i7);},
-            inputs1,
-            inputs2,
-            inputs3,
-            inputs4,
-            inputs5,
-            inputs6,
-            inputs7,
-            empty(),
-            reporter);
-    }
-
-    template <
-        typename Function,
-        typename Container1,
-        typename Container2,
-        typename Container3,
-        typename Container4,
-        typename Container5,
-        typename Container6,
-        
-        typename std::enable_if<! std::is_base_of<Reporter, Container6>::value, int>::type = 0>
-    static void verifyAllCombinations(
-        Function converter,
-        const Container1& inputs1,
-        const Container2& inputs2,
-        const Container3& inputs3,
-        const Container4& inputs4,
-        const Container5& inputs5,
-        const Container6& inputs6,
-        const Reporter& reporter = DefaultReporter())
-    {
-        verifyAllCombinations(
-            [&](typename Container1::value_type i1,
-                typename Container2::value_type i2,
-                typename Container3::value_type i3,
-                typename Container4::value_type i4,
-                typename Container5::value_type i5,
-                typename Container6::value_type i6,
-                Empty){return converter(i1, i2, i3, i4, i5, i6);},
-            inputs1,
-            inputs2,
-            inputs3,
-            inputs4,
-            inputs5,
-            inputs6,
-            empty(),
-            reporter);
-    }
-
-    template <
-        typename Function,
-        typename Container1,
-        typename Container2,
-        typename Container3,
-        typename Container4,
-        typename Container5,
-        
-        typename std::enable_if<! std::is_base_of<Reporter, Container5>::value, int>::type = 0>
-    static void verifyAllCombinations(
-        Function converter,
-        const Container1& inputs1,
-        const Container2& inputs2,
-        const Container3& inputs3,
-        const Container4& inputs4,
-        const Container5& inputs5,
-        const Reporter& reporter = DefaultReporter())
-    {
-        verifyAllCombinations(
-            [&](typename Container1::value_type i1,
-                typename Container2::value_type i2,
-                typename Container3::value_type i3,
-                typename Container4::value_type i4,
-                typename Container5::value_type i5,
-                Empty){return converter(i1, i2, i3, i4, i5);},
-            inputs1,
-            inputs2,
-            inputs3,
-            inputs4,
-            inputs5,
-            empty(),
-            reporter);
-    }
-
-    template <
-        typename Function,
-        typename Container1,
-        typename Container2,
-        typename Container3,
-        typename Container4,
-        
-        typename std::enable_if<! std::is_base_of<Reporter, Container4>::value, int>::type = 0>
-    static void verifyAllCombinations(
-        Function converter,
-        const Container1& inputs1,
-        const Container2& inputs2,
-        const Container3& inputs3,
-        const Container4& inputs4,
-        const Reporter& reporter = DefaultReporter())
-    {
-        verifyAllCombinations(
-            [&](typename Container1::value_type i1,
-                typename Container2::value_type i2,
-                typename Container3::value_type i3,
-                typename Container4::value_type i4,
-                Empty){return converter(i1, i2, i3, i4);},
-            inputs1,
-            inputs2,
-            inputs3,
-            inputs4,
-            empty(),
-            reporter);
-    }
-
-    template <
-        typename Function,
-        typename Container1,
-        typename Container2,
-        typename Container3,
-        
-        typename std::enable_if<! std::is_base_of<Reporter, Container3>::value, int>::type = 0>
-    static void verifyAllCombinations(
-        Function converter,
-        const Container1& inputs1,
-        const Container2& inputs2,
-        const Container3& inputs3,
-        const Reporter& reporter = DefaultReporter())
-    {
-        verifyAllCombinations(
-            [&](typename Container1::value_type i1,
-                typename Container2::value_type i2,
-                typename Container3::value_type i3,
-                Empty){return converter(i1, i2, i3);},
-            inputs1,
-            inputs2,
-            inputs3,
-            empty(),
-            reporter);
-    }
-
-    template <
-        typename Function,
-        typename Container1,
-        typename Container2,
-        
-        typename std::enable_if<! std::is_base_of<Reporter, Container2>::value, int>::type = 0>
-    static void verifyAllCombinations(
-        Function converter,
-        const Container1& inputs1,
-        const Container2& inputs2,
-        const Reporter& reporter = DefaultReporter())
-    {
-        verifyAllCombinations(
-            [&](typename Container1::value_type i1,
-                typename Container2::value_type i2,
-                Empty){return converter(i1, i2);},
-            inputs1,
-            inputs2,
-            empty(),
-            reporter);
-    }
-
-    template <
-        typename Function,
-        typename Container1,
-        
-        typename std::enable_if<! std::is_base_of<Reporter, Container1>::value, int>::type = 0>
-    static void verifyAllCombinations(
-        Function converter,
-        const Container1& inputs1,
-        const Reporter& reporter = DefaultReporter())
-    {
-        verifyAllCombinations(
-            [&](typename Container1::value_type i1,
-                Empty){return converter(i1);},
-            inputs1,
-            empty(),
-            reporter);
-    }
-
-    
-    
-    
-    using EmptyContainer = std::vector<Empty>;
-    static EmptyContainer empty()
-    {
-        return EmptyContainer{Empty()};
-    }
-};
-
-#endif
-
- // ******************** From: GoogleTestApprovals.h
-#ifndef APPROVALTESTS_CPP_GOOGLTESTAPPPROVALS_H
-#define APPROVALTESTS_CPP_GOOGLTESTAPPPROVALS_H
-
-
-#ifdef APPROVALS_GOOGLETEST_EXISTING_MAIN
-#define APPROVALS_GOOGLETEST
-#endif
-
-#ifdef APPROVALS_GOOGLETEST
-
-// <SingleHpp unalterable>
-#include "gtest/gtest.h"
-
-
-class GoogleTestListener : public ::testing::EmptyTestEventListener
-{
-    TestName currentTest;
-public:
-    bool isDuplicate(std::string testFileNameWithExtension, std::string testCaseName)
-    {
-        for( auto check : GoogleCustomizationsFactory::getEquivalencyChecks())
-        {
-            if (check(testFileNameWithExtension, testCaseName))
-            {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    virtual void OnTestStart(const ::testing::TestInfo& testInfo) override
-    {
-        currentTest.setFileName(testInfo.file());
-        currentTest.sections = {};
-        if (! isDuplicate(currentTest.getFileName(), testInfo.test_case_name()))
-        {
-            currentTest.sections.push_back(testInfo.test_case_name());
-        }
-        if (! std::string(testInfo.name()).empty())
-        {
-            currentTest.sections.push_back(testInfo.name());
-        }
-        
-        ApprovalTestNamer::currentTest(&currentTest);
-    }
-};
-
-inline void initializeApprovalTestsForGoogleTests() {
-    auto& listeners = testing::UnitTest::GetInstance()->listeners();
-    listeners.Append(new GoogleTestListener);
 }
 
-#ifndef APPROVALS_GOOGLETEST_EXISTING_MAIN
-int main(int argc, char** argv)
+// ******************** From: TemplatedCustomNamer.cpp
+
+#include <functional>
+#include <utility>
+
+namespace
 {
-    ::testing::InitGoogleTest(&argc, argv);
-    initializeApprovalTestsForGoogleTests();
-    return RUN_ALL_TESTS();
-}
-#endif //APPROVALS_GOOGLETEST_EXISTING_MAIN
-
-// </SingleHpp>
-#endif
-#endif 
-
- // ******************** From: DocTestApprovals.h
-#ifndef APPROVALTESTS_CPP_DOCTESTAPPROVALS_H
-#define APPROVALTESTS_CPP_DOCTESTAPPROVALS_H
-
-
-// <SingleHpp unalterable>
-#ifdef APPROVALS_DOCTEST
-
-#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
-
-#include <doctest.h>
-
-// anonymous namespace to prevent compiler -Wsubobject-linkage warnings
-// This is OK as this code is only compiled on main()
-namespace {
-    struct AbstractReporter : doctest::IReporter {
-        virtual void report_query(const doctest::QueryData&) {}
-        // called when the whole test run starts
-        virtual void test_run_start() {}
-
-        // called when the whole test run ends (caching a pointer to the input doesn't make sense here)
-        virtual void test_run_end(const doctest::TestRunStats &) {}
-
-        // called when a test case is started (safe to cache a pointer to the input)
-        virtual void test_case_start(const doctest::TestCaseData &) {}
-
-        // called when a test case has ended
-        virtual void test_case_end(const doctest::CurrentTestCaseStats &) {}
-
-        // called when an exception is thrown from the test case (or it crashes)
-        virtual void test_case_exception(const doctest::TestCaseException &) {}
-
-        // called whenever a subcase is entered (don't cache pointers to the input)
-        virtual void subcase_start(const doctest::SubcaseSignature &) {}
-
-        // called whenever a subcase is exited (don't cache pointers to the input)
-        virtual void subcase_end() {}
-
-        // called for each assert (don't cache pointers to the input)
-        virtual void log_assert(const doctest::AssertData &) {}
-
-        // called for each message (don't cache pointers to the input)
-        virtual void log_message(const doctest::MessageData &) {}
-
-        // called when a test case is skipped either because it doesn't pass the filters, has a skip decorator
-        // or isn't in the execution range (between first and last) (safe to cache a pointer to the input)
-        virtual void test_case_skipped(const doctest::TestCaseData &) {}
-
-
-    };
-
-    struct DocTestApprovalListener : AbstractReporter {
-        TestName currentTest;
-
-        // constructor has to accept the ContextOptions by ref as a single argument
-        DocTestApprovalListener(const doctest::ContextOptions & /*in*/) {
-        }
-
-        void test_case_start(const doctest::TestCaseData &testInfo) override {
-
-            currentTest.sections.push_back(testInfo.m_name);
-            currentTest.setFileName(testInfo.m_file);
-            ApprovalTestNamer::currentTest(&currentTest);
-        }
-
-        void test_case_end(const doctest::CurrentTestCaseStats & /*in*/) override {
-
-            while (!currentTest.sections.empty()) {
-                currentTest.sections.pop_back();
-            }
-        }
-
-        void subcase_start(const doctest::SubcaseSignature &signature) override {
-
-            currentTest.sections.push_back(signature.m_name);
-        }
-
-        void subcase_end() override {
-
-            currentTest.sections.pop_back();
-        }
-    };
-}
-
-REGISTER_LISTENER("approvals", 0, DocTestApprovalListener);
-
-
-#endif // APPROVALS_DOCTEST
-// </SingleHpp>
-#endif 
-
- // ******************** From: GoogleConfiguration.h
-#ifndef APPROVALTESTS_CPP_GOOGLECONFIGURATION_H
-#define APPROVALTESTS_CPP_GOOGLECONFIGURATION_H
-
-
-class GoogleConfiguration
-{
-public:
-    static bool addTestCaseNameRedundancyCheck(GoogleCustomizationsFactory::Comparator comparator)
+    std::string replaceIfContains(std::string input,
+                                  std::string pattern,
+                                  std::function<std::string(void)> replacer)
     {
-        return GoogleCustomizationsFactory::addTestCaseNameRedundancyCheck(comparator);
-    }
-
-    static bool addIgnorableTestCaseNameSuffix(std::string suffix)
-    {
-        return addTestCaseNameRedundancyCheck( createIgnorableTestCaseNameSuffixCheck(suffix) );
-    }
-
-    static GoogleCustomizationsFactory::Comparator createIgnorableTestCaseNameSuffixCheck( const std::string& suffix )
-    {
-        return [suffix](std::string testFileNameWithExtension, std::string testCaseName)
+        if (!ApprovalTests::StringUtils::contains(input, pattern))
         {
-            if (testCaseName.length() <= suffix.length() || !StringUtils::endsWith(testCaseName, suffix))
-            {
-                return false;
-            }
-
-            auto withoutSuffix = testCaseName.substr(0, testCaseName.length() - suffix.length());
-            auto withFileExtension = withoutSuffix + ".";
-            return StringUtils::contains(testFileNameWithExtension, withFileExtension);
-        };
+            return input;
+        }
+        return ApprovalTests::StringUtils::replaceAll(input, pattern, replacer());
     }
-};
+}
 
-#endif 
-
- // ******************** From: OkraApprovals.h
-#ifndef APPROVALTESTS_CPP_OKRAAPPPROVALS_H
-#define APPROVALTESTS_CPP_OKRAAPPPROVALS_H
-
-#ifdef APPROVALS_OKRA
-
-// <SingleHpp unalterable>
-#include "Okra.h"
-
-
-struct OkraApprovalListener : public okra::IListener
+namespace ApprovalTests
 {
- TestName currentTest;
+    TemplatedCustomNamer::TemplatedCustomNamer(std::string templateString)
+        : template_(std::move(templateString))
+    {
+        if (!StringUtils::contains(template_, "{ApprovedOrReceived}"))
+        {
+            throw std::runtime_error(
+                "Template must contain `{ApprovedOrReceived}` or the received and "
+                "approved files will not be unique.\n"
+                "Template: " +
+                template_);
+        }
+    }
 
-public:
- void OnStart(const okra::TestInfo &testInfo) override
- {
-  currentTest.fileName = testInfo.file_path;
-  currentTest.sections = {testInfo.name};
-  ApprovalTestNamer::currentTest(&currentTest);
- }
+    Path TemplatedCustomNamer::constructFromTemplate(
+        const std::string& extensionWithDot,
+        const std::string& approvedOrReceivedReplacement) const
+    {
+        std::string result = template_;
+        auto testSourceDirectory = "{TestSourceDirectory}";
+        auto relativeTestSourceDirectory = "{RelativeTestSourceDirectory}";
+        auto approvalsSubdirectory = "{ApprovalsSubdirectory}";
+        auto testFileName = "{TestFileName}";
+        auto testCaseName = "{TestCaseName}";
+        auto approvedOrReceived = "{ApprovedOrReceived}";
+        auto fileExtension = "{FileExtension}";
 
- void OnEnd(const okra::TestInfo &testInfo, std::chrono::high_resolution_clock::duration duration) override {
- }
- void OnFail(const std::string &message) override {
- }
-};
+        using namespace ApprovalTests;
 
-OKRA_REGISTER_LISTENER(OkraApprovalListener);
-// </SingleHpp>
-#endif
-#endif 
+        // clang-format off
+        result = replaceIfContains(result, fileExtension, [&](){return extensionWithDot.substr(1);});
+        result = replaceIfContains(result, approvalsSubdirectory, [&](){return namer_.getApprovalsSubdirectory();});
+        result = replaceIfContains(result, relativeTestSourceDirectory, [&](){return namer_.getRelativeTestSourceDirectory();});
+        result = replaceIfContains(result, testFileName, [&](){return namer_.getSourceFileName();});
+        result = replaceIfContains(result, testCaseName, [&](){return namer_.getTestName();});
+        result = replaceIfContains(result, testSourceDirectory, [&](){return namer_.getTestSourceDirectory();});
+        result = replaceIfContains(result, approvedOrReceived, [&](){return approvedOrReceivedReplacement;});
+        // clang-format on
 
- // ******************** From: AutoApproveIfMissingReporter.h
-#ifndef APPROVALTESTS_CPP_AUTOAPPROVEIFMISSINGREPORTER_H
-#define APPROVALTESTS_CPP_AUTOAPPROVEIFMISSINGREPORTER_H
+        // Convert to native directory separators:
+        return Path(result);
+    }
 
+    std::string TemplatedCustomNamer::getApprovedFile(std::string extensionWithDot) const
+    {
+        return getApprovedFileAsPath(extensionWithDot).toString();
+    }
 
-class AutoApproveIfMissingReporter : public Reporter
+    std::string TemplatedCustomNamer::getReceivedFile(std::string extensionWithDot) const
+    {
+        return getReceivedFileAsPath(extensionWithDot).toString();
+    }
+
+    Path TemplatedCustomNamer::getApprovedFileAsPath(std::string extensionWithDot) const
+    {
+        return constructFromTemplate(extensionWithDot, "approved");
+    }
+
+    Path TemplatedCustomNamer::getReceivedFileAsPath(std::string extensionWithDot) const
+    {
+        return constructFromTemplate(extensionWithDot, "received");
+    }
+
+    std::shared_ptr<TemplatedCustomNamer>
+    TemplatedCustomNamer::create(std::string templateString)
+    {
+        return std::make_shared<TemplatedCustomNamer>(templateString);
+    }
+
+    DefaultNamerDisposer
+    TemplatedCustomNamer::useAsDefaultNamer(std::string templateString)
+    {
+        return Approvals::useAsDefaultNamer([=]() { return create(templateString); });
+    }
+}
+
+// ******************** From: AutoApproveIfMissingReporter.cpp
+
+namespace ApprovalTests
 {
-public:
-    bool report(std::string received, std::string approved) const override
+    bool AutoApproveIfMissingReporter::report(std::string received,
+                                              std::string approved) const
     {
         if (FileUtils::fileExists(approved))
         {
@@ -2478,129 +4653,2159 @@ public:
 
         return AutoApproveReporter().report(received, approved);
     }
-};
+}
 
-#endif 
+// ******************** From: AutoApproveReporter.cpp
 
- // ******************** From: BlockingReporter.h
-#ifndef APPROVALTESTS_CPP_BLOCKINGREPORTER_H
-#define APPROVALTESTS_CPP_BLOCKINGREPORTER_H
+#include <iostream>
 
-
-
-class BlockingReporter : public Reporter
+namespace ApprovalTests
 {
-private:
-    std::shared_ptr<Blocker> blocker;
+    bool AutoApproveReporter::report(std::string received, std::string approved) const
+    {
+        std::cout << "file " << approved
+                  << " automatically approved - next run should succeed\n";
+        FileUtilsSystemSpecific::copyFile(received, approved);
+        return true;
+    }
+}
 
-    BlockingReporter() = delete;
+// ******************** From: BlockingReporter.cpp
 
-public:
-    BlockingReporter( std::shared_ptr<Blocker> blocker ) : blocker(blocker)
+namespace ApprovalTests
+{
+    BlockingReporter::BlockingReporter(std::shared_ptr<Blocker> blocker_)
+        : blocker(std::move(blocker_))
     {
     }
 
-    static std::shared_ptr<BlockingReporter> onMachineNamed( const std::string& machineName )
+    std::shared_ptr<BlockingReporter>
+    BlockingReporter::onMachineNamed(const std::string& machineName)
     {
-        auto machineBlocker = std::make_shared<MachineBlocker>( MachineBlocker::onMachineNamed(machineName) );
+        auto machineBlocker =
+            std::make_shared<MachineBlocker>(MachineBlocker::onMachineNamed(machineName));
         return std::make_shared<BlockingReporter>(machineBlocker);
     }
 
-    static std::shared_ptr<BlockingReporter> onMachinesNotNamed( const std::string& machineName )
+    std::shared_ptr<BlockingReporter>
+    BlockingReporter::onMachinesNotNamed(const std::string& machineName)
     {
-        auto machineBlocker = std::make_shared<MachineBlocker>( MachineBlocker::onMachinesNotNamed(machineName) );
+        auto machineBlocker = std::make_shared<MachineBlocker>(
+            MachineBlocker::onMachinesNotNamed(machineName));
         return std::make_shared<BlockingReporter>(machineBlocker);
     }
 
-    virtual bool report(std::string , std::string ) const override
+    bool BlockingReporter::report(std::string, std::string) const
     {
         return blocker->isBlockingOnThisMachine();
     }
-};
+}
 
-#endif 
+// ******************** From: CIBuildOnlyReporter.cpp
 
- // ******************** From: ClipboardReporter.h
-#ifndef APPROVALTESTS_CPP_COMMANDLINEREPORTER_H
-#define APPROVALTESTS_CPP_COMMANDLINEREPORTER_H
-
-
-
-
-class ClipboardReporter : public Reporter {
-public:
-    static std::string getCommandLineFor(std::string received, std::string approved, bool isWindows)
+namespace ApprovalTests
+{
+    CIBuildOnlyReporter::CIBuildOnlyReporter(std::shared_ptr<Reporter> reporter)
+        : m_reporter(reporter)
     {
-        if (isWindows) {
+    }
+
+    bool CIBuildOnlyReporter::report(std::string received, std::string approved) const
+    {
+        if (!isRunningUnderCI())
+        {
+            return false;
+        }
+        m_reporter->report(received, approved);
+        // Return true regardless of whether our report succeeded or not,
+        // so that no later reporters run.
+        return true;
+    }
+
+    bool CIBuildOnlyReporter::isRunningUnderCI()
+    {
+        /*
+        auto AppVeyor = {"CI", "APPVEYOR"}; // https://www.appveyor.com/docs/environment-variables/
+        auto AzurePipelines = {"TF_BUILD"}; // https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&viewFallbackFrom=vsts&tabs=yaml
+        auto GitHubActions = {"GITHUB_ACTIONS"}; // https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables
+        auto GoCD = {"GO_SERVER_URL"}: // https://docs.gocd.org/current/faq/dev_use_current_revision_in_build.html
+        auto Jenkins = {"JENKINS_URL"}: // https://wiki.jenkins.io/display/JENKINS/Building+a+software+project
+        auto TeamCity = {"TEAMCITY_VERSION"}; // https://confluence.jetbrains.com/display/TCD18/Predefined+Build+Parameters
+        auto Travis = {"CI", "TRAVIS", "CONTINUOUS_INTEGRATION"}; // https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
+        auto environmentVariablesForCI = combine({
+            AppVeyor,
+            AzurePipelines,
+            GitHubActions,
+            GoCD
+            Jenkins,
+            TeamCity,
+            Travis,
+        });
+         */
+        auto environmentVariablesForCI = {
+            "CI",
+            "CONTINUOUS_INTEGRATION",
+            "GITHUB_ACTIONS",
+            "GO_SERVER_URL",
+            "JENKINS_URL",
+            "TEAMCITY_VERSION",
+            "TF_BUILD"
+        };
+        for (const auto& variable : environmentVariablesForCI)
+        {
+            if (!SystemUtils::safeGetEnv(variable).empty())
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+// ******************** From: CIBuildOnlyReporterUtils.cpp
+
+namespace ApprovalTests
+{
+    FrontLoadedReporterDisposer CIBuildOnlyReporterUtils::useAsFrontLoadedReporter(
+        const std::shared_ptr<Reporter>& reporter)
+    {
+        return Approvals::useAsFrontLoadedReporter(
+            std::make_shared<ApprovalTests::CIBuildOnlyReporter>(reporter));
+    }
+}
+
+// ******************** From: ClipboardReporter.cpp
+
+namespace ApprovalTests
+{
+    std::string ClipboardReporter::getCommandLineFor(const std::string& received,
+                                                     const std::string& approved,
+                                                     bool isWindows)
+    {
+        if (isWindows)
+        {
             return std::string("move /Y ") + "\"" + received + "\" \"" + approved + "\"";
-        } else {
+        }
+        else
+        {
             return std::string("mv ") + "\"" + received + "\" \"" + approved + "\"";
         }
     }
 
-    virtual bool report(std::string received, std::string approved) const override
+    bool ClipboardReporter::report(std::string received, std::string approved) const
     {
-        copyToClipboard(getCommandLineFor(received, approved, SystemUtils::isWindowsOs()));
+        copyToClipboard(
+            getCommandLineFor(received, approved, SystemUtils::isWindowsOs()));
         return true;
     }
 
-    static void copyToClipboard(const std::string& newClipboard) {
-        
-
-        const std::string clipboardCommand = SystemUtils::isWindowsOs() ? "clip" : "pbclip";
-        auto cmd = std::string("echo ") + newClipboard + " | " + clipboardCommand;
-        system(cmd.c_str());
-    }
-};
-
-#endif 
-
- // ******************** From: CombinationReporter.h
-#ifndef APPROVALTESTS_CPP_COMBINATIONREPORTER_H
-#define APPROVALTESTS_CPP_COMBINATIONREPORTER_H
-
-
-class CombinationReporter : public Reporter
-{
-private:
-    std::vector< std::unique_ptr<Reporter> > reporters;
-public:
-    
-    CombinationReporter(std::vector<Reporter*> theReporters)
+    void ClipboardReporter::copyToClipboard(const std::string& newClipboard)
     {
-        for(auto r : theReporters)
+        /*
+     This will probably not work on Linux.
+
+     From https://stackoverflow.com/a/750466/104370
+     In case of X, yes, there's xclip (and others). xclip -selection c will send data to the clipboard that
+     works with Ctrl-C, Ctrl-V in most applications.
+
+     If you're trying to talk to the Mac OS X clipboard, there's pbcopy.
+
+     If you're in Linux terminal mode (no X) then maybe you need to look into gpm.
+
+     There's also GNU screen which has a clipboard. To put stuff in there, look at the screen command "readreg".
+
+     Under Windows/cygwin, use /dev/clipboard or clip for newer versions of Windows (at least Windows 10).
+     */
+
+        std::string clipboardCommand;
+        if (SystemUtils::isWindowsOs())
+        {
+            clipboardCommand = "clip";
+        }
+        else if (SystemUtils::isMacOs())
+        {
+            clipboardCommand = "pbcopy";
+        }
+        else
+        {
+            clipboardCommand = "pbclip";
+        }
+        auto cmd = std::string("echo ") + newClipboard + " | " + clipboardCommand;
+        SystemUtils::runSystemCommandOrThrow(cmd);
+    }
+}
+
+// ******************** From: CombinationReporter.cpp
+
+namespace ApprovalTests
+{
+    CombinationReporter::CombinationReporter(const std::vector<Reporter*>& theReporters)
+    {
+        for (auto r : theReporters)
         {
             reporters.push_back(std::unique_ptr<Reporter>(r));
         }
     }
 
-    bool report(std::string received, std::string approved) const override
+    bool CombinationReporter::report(std::string received, std::string approved) const
     {
         bool result = false;
-        for(auto& r : reporters)
+        for (auto& r : reporters)
         {
             result |= r->report(received, approved);
         }
         return result;
     }
-};
+}
 
-#endif 
+// ******************** From: CommandReporter.cpp
 
- // ******************** From: QuietReporter.h
-#ifndef APPROVALTESTS_CPP_QUIETREPORTER_H
-#define APPROVALTESTS_CPP_QUIETREPORTER_H
-
-
-
-class QuietReporter : public Reporter
+namespace ApprovalTests
 {
-public:
-    bool report(std::string , std::string ) const override
+    std::string CommandReporter::assembleFullCommand(const std::string& received,
+                                                     const std::string& approved) const
+    {
+        auto convertedCommand = '"' + converter->convertProgramForCygwin(cmd) + '"';
+        auto convertedReceived =
+            '"' + converter->convertFileArgumentForCygwin(received) + '"';
+        auto convertedApproved =
+            '"' + converter->convertFileArgumentForCygwin(approved) + '"';
+
+        std::string args;
+        args = StringUtils::replaceAll(
+            arguments, DiffInfo::receivedFileTemplate(), convertedReceived);
+        args = StringUtils::replaceAll(
+            args, DiffInfo::approvedFileTemplate(), convertedApproved);
+
+        return convertedCommand + ' ' + args;
+    }
+
+    CommandReporter::CommandReporter(std::string command, CommandLauncher* launcher)
+        : cmd(std::move(command)), l(launcher)
+    {
+        checkForCygwin();
+    }
+
+    CommandReporter::CommandReporter(std::string command,
+                                     std::string args,
+                                     CommandLauncher* launcher)
+        : cmd(std::move(command)), arguments(std::move(args)), l(launcher)
+    {
+        checkForCygwin();
+    }
+
+    bool CommandReporter::exists(const std::string& command)
+    {
+        bool foundByWhich = false;
+        if (!SystemUtils::isWindowsOs())
+        {
+            std::string which = "which " + command + " > /dev/null 2>&1";
+            int result = system(which.c_str());
+            foundByWhich = (result == 0);
+        }
+        return foundByWhich || FileUtils::fileExists(command);
+    }
+
+    bool CommandReporter::report(std::string received, std::string approved) const
+    {
+        if (!exists(cmd))
+        {
+            return false;
+        }
+        FileUtils::ensureFileExists(approved);
+        return l->launch(assembleFullCommand(received, approved));
+    }
+
+    std::string CommandReporter::getCommandLine(const std::string& received,
+                                                const std::string& approved) const
+    {
+        return l->getCommandLine(assembleFullCommand(received, approved));
+    }
+
+    void CommandReporter::checkForCygwin()
+    {
+        useCygwinConversions(SystemUtils::isCygwin());
+    }
+
+    void CommandReporter::useCygwinConversions(bool useCygwin)
+    {
+        if (useCygwin)
+        {
+            converter = std::make_shared<ConvertForCygwin>();
+        }
+        else
+        {
+            converter = std::make_shared<DoNothing>();
+        }
+    }
+}
+
+// ******************** From: ConvertForCygwin.cpp
+
+namespace ApprovalTests
+{
+    std::string ConvertForCygwin::convertProgramForCygwin(const std::string& filePath)
+    {
+        return "$(cygpath '" + filePath + "')";
+    }
+
+    std::string
+    ConvertForCygwin::convertFileArgumentForCygwin(const std::string& filePath)
+    {
+        return "$(cygpath -aw '" + filePath + "')";
+    }
+
+    std::string DoNothing::convertProgramForCygwin(const std::string& filePath)
+    {
+        return filePath;
+    }
+
+    std::string DoNothing::convertFileArgumentForCygwin(const std::string& filePath)
+    {
+        return filePath;
+    }
+}
+
+// ******************** From: CustomReporter.cpp
+
+namespace ApprovalTests
+{
+    std::shared_ptr<GenericDiffReporter> CustomReporter::create(std::string path,
+                                                                Type type)
+    {
+        return create(std::move(path), DiffInfo::getDefaultArguments(), type);
+    }
+
+    std::shared_ptr<GenericDiffReporter>
+    CustomReporter::create(std::string path, std::string arguments, Type type)
+    {
+        DiffInfo info(std::move(path), std::move(arguments), type);
+        return std::make_shared<GenericDiffReporter>(info);
+    }
+
+    std::shared_ptr<GenericDiffReporter> CustomReporter::createForegroundReporter(
+        std::string path, Type type, bool allowNonZeroExitCodes)
+    {
+        return createForegroundReporter(std::move(path),
+                                        DiffInfo::getDefaultArguments(),
+                                        type,
+                                        allowNonZeroExitCodes);
+    }
+
+    std::shared_ptr<GenericDiffReporter> CustomReporter::createForegroundReporter(
+        std::string path, std::string arguments, Type type, bool allowNonZeroExitCodes)
+    {
+        DiffInfo info(std::move(path), std::move(arguments), type);
+        auto reporter = std::make_shared<GenericDiffReporter>(info);
+        reporter->launcher.setForeground(true);
+        reporter->launcher.setAllowNonZeroExitCodes(allowNonZeroExitCodes);
+        return reporter;
+    }
+}
+
+// ******************** From: DefaultFrontLoadedReporter.cpp
+
+namespace ApprovalTests
+{
+    DefaultFrontLoadedReporter::DefaultFrontLoadedReporter()
+        : FirstWorkingReporter({new CIBuildOnlyReporter()})
+    {
+    }
+}
+
+// ******************** From: DefaultReporter.cpp
+
+namespace ApprovalTests
+{
+    bool DefaultReporter::report(std::string received, std::string approved) const
+    {
+        return DefaultReporterFactory::getDefaultReporter()->report(received, approved);
+    }
+}
+
+// ******************** From: DefaultReporterDisposer.cpp
+
+namespace ApprovalTests
+{
+    DefaultReporterDisposer::DefaultReporterDisposer(
+        const std::shared_ptr<Reporter>& reporter)
+    {
+        previous_result = DefaultReporterFactory::getDefaultReporter();
+        DefaultReporterFactory::setDefaultReporter(reporter);
+    }
+
+    DefaultReporterDisposer::~DefaultReporterDisposer()
+    {
+        DefaultReporterFactory::setDefaultReporter(previous_result);
+    }
+}
+
+// ******************** From: DefaultReporterFactory.cpp
+
+namespace ApprovalTests
+{
+    std::shared_ptr<Reporter>& DefaultReporterFactory::defaultReporter()
+    {
+        static std::shared_ptr<Reporter> reporter = std::make_shared<DiffReporter>();
+        return reporter;
+    }
+
+    std::shared_ptr<Reporter> DefaultReporterFactory::getDefaultReporter()
+    {
+        return defaultReporter();
+    }
+
+    void
+    DefaultReporterFactory::setDefaultReporter(const std::shared_ptr<Reporter>& reporter)
+    {
+        defaultReporter() = reporter;
+    }
+}
+
+// ******************** From: DiffInfo.cpp
+
+namespace ApprovalTests
+{
+    std::string DiffInfo::receivedFileTemplate()
+    {
+        return "{Received}";
+    }
+
+    std::string DiffInfo::approvedFileTemplate()
+    {
+        return "{Approved}";
+    }
+
+    std::string DiffInfo::programFileTemplate()
+    {
+        return "{ProgramFiles}";
+    }
+
+    std::string DiffInfo::getDefaultArguments()
+    {
+        return receivedFileTemplate() + ' ' + approvedFileTemplate();
+    }
+
+    DiffInfo::DiffInfo(std::string program_, Type type_)
+        : program(std::move(program_)), arguments(getDefaultArguments()), type(type_)
+    {
+    }
+
+    DiffInfo::DiffInfo(std::string program_, std::string arguments_, Type type_)
+        : program(std::move(program_)), arguments(std::move(arguments_)), type(type_)
+    {
+    }
+
+    std::vector<std::string> DiffInfo::getProgramFileLocations()
+    {
+        std::vector<std::string> possibleWindowsPaths;
+        const std::vector<const char*> envVars = {
+            "ProgramFiles", "ProgramW6432", "ProgramFiles(x86)"};
+
+        for (const auto& envVar : envVars)
+        {
+            std::string envVarValue = SystemUtils::safeGetEnv(envVar);
+            if (!envVarValue.empty())
+            {
+                envVarValue += '\\';
+                possibleWindowsPaths.push_back(envVarValue);
+            }
+        }
+        return possibleWindowsPaths;
+    }
+
+    std::string DiffInfo::getProgramForOs() const
+    {
+        std::string result = program;
+        if (result.rfind(programFileTemplate(), 0) == 0)
+        {
+            std::vector<std::string> possibleWindowsPaths = getProgramFileLocations();
+            for (const auto& path : possibleWindowsPaths)
+            {
+                auto result1 =
+                    StringUtils::replaceAll(result, programFileTemplate(), path);
+                if (FileUtils::fileExists(result1))
+                {
+                    return result1;
+                }
+            }
+        }
+        return result;
+    }
+}
+
+// ******************** From: DiffPrograms.cpp
+
+///////////////////////////////////////////////////////////////////////////////
+#define APPROVAL_TESTS_MACROS_ENTRY(name, defaultValue)                                  \
+    DiffInfo name()                                                                      \
+    {                                                                                    \
+        return defaultValue;                                                             \
+    }
+///////////////////////////////////////////////////////////////////////////////
+
+namespace ApprovalTests
+{
+    namespace DiffPrograms
+    {
+
+        namespace Mac
+        {
+            APPROVAL_TESTS_MACROS_ENTRY(
+                DIFF_MERGE,
+                DiffInfo("/Applications/DiffMerge.app/Contents/MacOS/DiffMerge",
+                         "{Received} {Approved} -nosplash",
+                         Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                ARAXIS_MERGE,
+                DiffInfo("/Applications/Araxis Merge.app/Contents/Utilities/compare",
+                         Type::TEXT_AND_IMAGE))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                BEYOND_COMPARE,
+                DiffInfo("/Applications/Beyond Compare.app/Contents/MacOS/bcomp",
+                         Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                KALEIDOSCOPE,
+                DiffInfo("/Applications/Kaleidoscope.app/Contents/MacOS/ksdiff",
+                         Type::TEXT_AND_IMAGE))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                SUBLIME_MERGE,
+                DiffInfo("/Applications/Sublime "
+                         "Merge.app/Contents/SharedSupport/bin/smerge",
+                         "mergetool --no-wait {Received} {Approved} -o {Approved}",
+                         Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                KDIFF3,
+                DiffInfo("/Applications/kdiff3.app/Contents/MacOS/kdiff3",
+                         "{Received} {Approved} -m -o {Approved}",
+                         Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                P4MERGE,
+                DiffInfo("/Applications/p4merge.app/Contents/MacOS/p4merge",
+                         Type::TEXT_AND_IMAGE))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                TK_DIFF,
+                DiffInfo("/Applications/TkDiff.app/Contents/MacOS/tkdiff", Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                VS_CODE,
+                DiffInfo("/Applications/Visual Studio "
+                         "Code.app/Contents/Resources/app/bin/code",
+                         "-d {Received} {Approved}",
+                         Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(CLION,
+                                        DiffInfo("clion",
+                                                 "nosplash diff {Received} {Approved}",
+                                                 Type::TEXT))
+        }
+
+        namespace Linux
+        {
+            APPROVAL_TESTS_MACROS_ENTRY(
+                SUBLIME_MERGE_SNAP,
+                DiffInfo("/snap/bin/sublime-merge",
+                         "mergetool --no-wait {Received} {Approved} -o {Approved}",
+                         Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                SUBLIME_MERGE_FLATPAK,
+                DiffInfo("/var/lib/flatpak/exports/bin/com.sublimemerge.App",
+                         "mergetool --no-wait {Received} {Approved} -o {Approved}",
+                         Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                SUBLIME_MERGE_REPOSITORY_PACKAGE,
+                DiffInfo("smerge",
+                         "mergetool --no-wait {Received} {Approved} -o {Approved}",
+                         Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                SUBLIME_MERGE_DIRECT_DOWNLOAD,
+                DiffInfo("/opt/sublime_merge/sublime_merge",
+                         "mergetool --no-wait {Received} {Approved} -o {Approved}",
+                         Type::TEXT))
+
+            // More ideas available from: https://www.tecmint.com/best-linux-file-diff-tools-comparison/
+            APPROVAL_TESTS_MACROS_ENTRY(KDIFF3,
+                                        DiffInfo("kdiff3",
+                                                 "{Received} {Approved} -m -o {Approved}",
+                                                 Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(MELD, DiffInfo("meld", Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(BEYOND_COMPARE,
+                                        DiffInfo("bcompare", Type::TEXT_AND_IMAGE))
+        }
+
+        namespace Windows
+        {
+            APPROVAL_TESTS_MACROS_ENTRY(
+                BEYOND_COMPARE_3,
+                DiffInfo("{ProgramFiles}Beyond Compare 3\\BCompare.exe",
+                         Type::TEXT_AND_IMAGE))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                BEYOND_COMPARE_4,
+                DiffInfo("{ProgramFiles}Beyond Compare 4\\BCompare.exe",
+                         Type::TEXT_AND_IMAGE))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                TORTOISE_IMAGE_DIFF,
+                DiffInfo("{ProgramFiles}TortoiseSVN\\bin\\TortoiseIDiff.exe",
+                         "/left:{Received} /right:{Approved}",
+                         Type::IMAGE))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                TORTOISE_TEXT_DIFF,
+                DiffInfo("{ProgramFiles}TortoiseSVN\\bin\\TortoiseMerge.exe", Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                TORTOISE_GIT_IMAGE_DIFF,
+                DiffInfo("{ProgramFiles}TortoiseGit\\bin\\TortoiseGitIDiff.exe",
+                         "/left:{Received} /right:{Approved}",
+                         Type::IMAGE))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                TORTOISE_GIT_TEXT_DIFF,
+                DiffInfo("{ProgramFiles}TortoiseGit\\bin\\TortoiseGitMerge.exe",
+                         Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(WIN_MERGE_REPORTER,
+                                        DiffInfo("{ProgramFiles}WinMerge\\WinMergeU.exe",
+                                                 Type::TEXT_AND_IMAGE))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                ARAXIS_MERGE,
+                DiffInfo("{ProgramFiles}Araxis\\Araxis Merge\\Compare.exe",
+                         Type::TEXT_AND_IMAGE))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                CODE_COMPARE,
+                DiffInfo("{ProgramFiles}Devart\\Code Compare\\CodeCompare.exe",
+                         Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                SUBLIME_MERGE,
+                DiffInfo("{ProgramFiles}Sublime Merge\\smerge.exe",
+                         "mergetool --no-wait {Received} {Approved} -o {Approved}",
+                         Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(KDIFF3,
+                                        DiffInfo("{ProgramFiles}KDiff3\\bin\\kdiff3.exe",
+                                                 "{Received} {Approved} -m -o {Approved}",
+                                                 Type::TEXT))
+
+            APPROVAL_TESTS_MACROS_ENTRY(
+                VS_CODE,
+                DiffInfo("{ProgramFiles}Microsoft VS Code\\Code.exe",
+                         "-d {Received} {Approved}",
+                         Type::TEXT))
+        }
+
+    }
+}
+
+// ******************** From: DiffReporter.cpp
+
+
+namespace ApprovalTests
+{
+    DiffReporter::DiffReporter()
+        : FirstWorkingReporter({new EnvironmentVariableReporter(),
+                                new Mac::MacDiffReporter(),
+                                new Linux::LinuxDiffReporter(),
+                                new Windows::WindowsDiffReporter()})
+    {
+    }
+}
+
+// ******************** From: EnvironmentVariableReporter.cpp
+
+namespace ApprovalTests
+{
+    bool EnvironmentVariableReporter::report(std::string received,
+                                             std::string approved) const
+    {
+        // Get the env var
+        const auto envVarName = environmentVariableName();
+        const auto envVar = SystemUtils::safeGetEnv(envVarName.c_str());
+        return report(envVar, received, approved);
+    }
+
+    bool EnvironmentVariableReporter::report(const std::string& envVar,
+                                             const std::string& received,
+                                             const std::string& approved) const
+    {
+        if (envVar.empty())
+        {
+            return false;
+        }
+
+        auto reporter = factory.createReporter(envVar);
+        auto known = factory.allSupportedReporterNames();
+
+        if (!reporter)
+        {
+            auto message = HelpMessages::getUnknownEnvVarReporterHelp(
+                EnvironmentVariableReporter::environmentVariableName(), envVar, known);
+            throw std::runtime_error(message);
+        }
+
+        auto reporter_worked = reporter->report(received, approved);
+
+        if (!reporter_worked)
+        {
+            auto message = HelpMessages::getInvalidEnvVarReporterHelp(
+                EnvironmentVariableReporter::environmentVariableName(), envVar, known);
+            throw std::runtime_error(message);
+        }
+
+        return reporter_worked;
+    }
+
+    std::string EnvironmentVariableReporter::environmentVariableName()
+    {
+        return "APPROVAL_TESTS_USE_REPORTER";
+    }
+}
+
+// ******************** From: FirstWorkingReporter.cpp
+
+namespace ApprovalTests
+{
+    FirstWorkingReporter::FirstWorkingReporter(const std::vector<Reporter*>& theReporters)
+    {
+        for (auto r : theReporters)
+        {
+            reporters.push_back(std::shared_ptr<Reporter>(r));
+        }
+    }
+
+    FirstWorkingReporter::FirstWorkingReporter(
+        const std::vector<std::shared_ptr<Reporter>>& reporters_)
+    {
+        this->reporters = reporters_;
+    }
+
+    bool FirstWorkingReporter::report(std::string received, std::string approved) const
+    {
+        for (auto& r : reporters)
+        {
+            if (r->report(received, approved))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+// ******************** From: FrontLoadedReporterDisposer.cpp
+
+namespace ApprovalTests
+{
+    FrontLoadedReporterDisposer::FrontLoadedReporterDisposer(
+        const std::shared_ptr<Reporter>& reporter)
+    {
+        previous_result = FrontLoadedReporterFactory::getFrontLoadedReporter();
+        FrontLoadedReporterFactory::setFrontLoadedReporter(reporter);
+    }
+
+    FrontLoadedReporterDisposer::~FrontLoadedReporterDisposer()
+    {
+        FrontLoadedReporterFactory::setFrontLoadedReporter(previous_result);
+    }
+}
+
+// ******************** From: FrontLoadedReporterFactory.cpp
+
+namespace ApprovalTests
+{
+    std::shared_ptr<Reporter>& FrontLoadedReporterFactory::frontLoadedReporter()
+    {
+        static std::shared_ptr<Reporter> reporter =
+            std::make_shared<DefaultFrontLoadedReporter>();
+        return reporter;
+    }
+
+    std::shared_ptr<Reporter> FrontLoadedReporterFactory::getFrontLoadedReporter()
+    {
+        return frontLoadedReporter();
+    }
+
+    void FrontLoadedReporterFactory::setFrontLoadedReporter(
+        const std::shared_ptr<Reporter>& reporter)
+    {
+        frontLoadedReporter() = reporter;
+    }
+}
+
+// ******************** From: GenericDiffReporter.cpp
+
+namespace ApprovalTests
+{
+    GenericDiffReporter::GenericDiffReporter(const std::string& program)
+        : CommandReporter(program, &launcher)
+    {
+    }
+
+    GenericDiffReporter::GenericDiffReporter(const DiffInfo& info)
+        : CommandReporter(info.getProgramForOs(), info.arguments, &launcher)
+    {
+    }
+}
+
+// ******************** From: LinuxReporters.cpp
+
+namespace ApprovalTests
+{
+    namespace Linux
+    {
+        SublimeMergeSnapReporter::SublimeMergeSnapReporter()
+            : GenericDiffReporter(DiffPrograms::Linux::SUBLIME_MERGE_SNAP())
+        {
+            launcher.setForeground(true);
+        }
+
+        SublimeMergeFlatpakReporter::SublimeMergeFlatpakReporter()
+            : GenericDiffReporter(DiffPrograms::Linux::SUBLIME_MERGE_FLATPAK())
+        {
+            launcher.setForeground(true);
+        }
+
+        SublimeMergeRepositoryPackageReporter::SublimeMergeRepositoryPackageReporter()
+            : GenericDiffReporter(DiffPrograms::Linux::SUBLIME_MERGE_REPOSITORY_PACKAGE())
+        {
+            launcher.setForeground(true);
+        }
+
+        SublimeMergeDirectDownloadReporter::SublimeMergeDirectDownloadReporter()
+            : GenericDiffReporter(DiffPrograms::Linux::SUBLIME_MERGE_DIRECT_DOWNLOAD())
+        {
+            launcher.setForeground(true);
+        }
+
+        SublimeMergeReporter::SublimeMergeReporter()
+            : FirstWorkingReporter({new SublimeMergeSnapReporter(),
+                                    new SublimeMergeFlatpakReporter(),
+                                    new SublimeMergeRepositoryPackageReporter(),
+                                    new SublimeMergeDirectDownloadReporter()})
+        {
+        }
+
+        KDiff3Reporter::KDiff3Reporter()
+            : GenericDiffReporter(DiffPrograms::Linux::KDIFF3())
+        {
+        }
+
+        MeldReporter::MeldReporter() : GenericDiffReporter(DiffPrograms::Linux::MELD())
+        {
+        }
+
+        BeyondCompareReporter::BeyondCompareReporter()
+            : GenericDiffReporter(DiffPrograms::Linux::BEYOND_COMPARE())
+        {
+        }
+
+        LinuxDiffReporter::LinuxDiffReporter()
+            : FirstWorkingReporter({
+                  new BeyondCompareReporter(),
+                  new MeldReporter(),
+                  new SublimeMergeReporter(),
+                  new KDiff3Reporter()
+              })
+        {
+        }
+    }
+}
+
+// ******************** From: MacReporters.cpp
+
+
+namespace ApprovalTests
+{
+    namespace Mac
+    {
+        DiffMergeReporter::DiffMergeReporter()
+            : GenericDiffReporter(DiffPrograms::Mac::DIFF_MERGE())
+        {
+        }
+
+        AraxisMergeReporter::AraxisMergeReporter()
+            : GenericDiffReporter(DiffPrograms::Mac::ARAXIS_MERGE())
+        {
+        }
+
+        VisualStudioCodeReporter::VisualStudioCodeReporter()
+            : GenericDiffReporter(DiffPrograms::Mac::VS_CODE())
+        {
+        }
+
+        BeyondCompareReporter::BeyondCompareReporter()
+            : GenericDiffReporter(DiffPrograms::Mac::BEYOND_COMPARE())
+        {
+        }
+
+        KaleidoscopeReporter::KaleidoscopeReporter()
+            : GenericDiffReporter(DiffPrograms::Mac::KALEIDOSCOPE())
+        {
+        }
+
+        SublimeMergeReporter::SublimeMergeReporter()
+            : GenericDiffReporter(DiffPrograms::Mac::SUBLIME_MERGE())
+        {
+            launcher.setForeground(true);
+        }
+
+        KDiff3Reporter::KDiff3Reporter()
+            : GenericDiffReporter(DiffPrograms::Mac::KDIFF3())
+        {
+        }
+
+        P4MergeReporter::P4MergeReporter()
+            : GenericDiffReporter(DiffPrograms::Mac::P4MERGE())
+        {
+        }
+        TkDiffReporter::TkDiffReporter()
+            : GenericDiffReporter(DiffPrograms::Mac::TK_DIFF())
+        {
+        }
+
+        CLionDiffReporter::CLionDiffReporter()
+            : GenericDiffReporter(DiffPrograms::Mac::CLION())
+        {
+        }
+
+        MacDiffReporter::MacDiffReporter()
+            : FirstWorkingReporter({
+                  new AraxisMergeReporter(),
+                  new BeyondCompareReporter(),
+                  new DiffMergeReporter(),
+                  new KaleidoscopeReporter(),
+                  new P4MergeReporter(),
+                  new SublimeMergeReporter(),
+                  new KDiff3Reporter(),
+                  new TkDiffReporter(),
+                  new VisualStudioCodeReporter(),
+                  new CLionDiffReporter()
+              })
+        {
+        }
+
+        bool MacDiffReporter::report(std::string received, std::string approved) const
+        {
+            if (!SystemUtils::isMacOs())
+            {
+                return false;
+            }
+            return FirstWorkingReporter::report(received, approved);
+        }
+    }
+}
+
+// ******************** From: QuietReporter.cpp
+
+namespace ApprovalTests
+{
+    bool QuietReporter::report(std::string, std::string) const
     {
         return true;
     }
-};
+}
 
-#endif 
+// ******************** From: ReporterFactory.cpp
 
+
+#include <map>
+#include <functional>
+
+#define APPROVAL_TESTS_REGISTER_REPORTER(name)                                           \
+    map[#name] = []() { return std::unique_ptr<Reporter>(new name); }
+
+namespace ApprovalTests
+{
+
+    std::string getOsPrefix()
+    {
+        if (SystemUtils::isMacOs())
+        {
+            return "Mac::";
+        }
+
+        if (SystemUtils::isWindowsOs())
+        {
+            return "Windows::";
+        }
+
+        return "Linux::";
+    }
+
+    ReporterFactory::ReporterFactory() : map(createMap())
+    {
+    }
+
+    ReporterFactory::Reporters ReporterFactory::createMap()
+    {
+        Reporters map;
+
+        APPROVAL_TESTS_REGISTER_REPORTER(AutoApproveIfMissingReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(AutoApproveReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(CIBuildOnlyReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(ClipboardReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(DefaultFrontLoadedReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(DefaultReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(DiffReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(EnvironmentVariableReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(QuietReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(TextDiffReporter);
+
+        APPROVAL_TESTS_REGISTER_REPORTER(Linux::BeyondCompareReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Linux::MeldReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Linux::SublimeMergeReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Linux::KDiff3Reporter);
+
+        APPROVAL_TESTS_REGISTER_REPORTER(Mac::AraxisMergeReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Mac::BeyondCompareReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Mac::DiffMergeReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Mac::KaleidoscopeReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Mac::P4MergeReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Mac::SublimeMergeReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Mac::KDiff3Reporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Mac::TkDiffReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Mac::VisualStudioCodeReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Mac::CLionDiffReporter);
+
+        APPROVAL_TESTS_REGISTER_REPORTER(Windows::TortoiseDiffReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Windows::TortoiseGitDiffReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Windows::BeyondCompareReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Windows::WinMergeReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Windows::AraxisMergeReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Windows::CodeCompareReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Windows::SublimeMergeReporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Windows::KDiff3Reporter);
+        APPROVAL_TESTS_REGISTER_REPORTER(Windows::VisualStudioCodeReporter);
+
+        return map;
+    }
+
+    std::unique_ptr<Reporter>
+    ReporterFactory::createReporter(const std::string& reporterName) const
+    {
+        auto osPrefix = getOsPrefix();
+
+        auto key = findReporterName(osPrefix, reporterName);
+
+        if (!key.empty())
+        {
+            return map.at(key)();
+        }
+
+        return std::unique_ptr<Reporter>();
+    }
+
+    std::vector<std::string> ReporterFactory::allSupportedReporterNames() const
+    {
+        std::vector<std::string> result;
+
+        for (auto& p : map)
+        {
+            result.push_back(p.first);
+        }
+
+        return result;
+    }
+
+    std::string ReporterFactory::findReporterName(const std::string& osPrefix,
+                                                  const std::string& reporterName) const
+    {
+        auto trimmedReporterName = StringUtils::trim(reporterName);
+        trimmedReporterName = StringUtils::toLower(trimmedReporterName);
+
+        std::vector<std::string> candidateNames = {
+            trimmedReporterName,
+            // Allow program names to be specified without Reporter suffix
+            trimmedReporterName + "reporter",
+            // Allow names without os namespace
+            StringUtils::toLower(osPrefix) + trimmedReporterName,
+            StringUtils::toLower(osPrefix) + trimmedReporterName + "reporter",
+        };
+
+        for (auto& candidateName : candidateNames)
+        {
+            auto iter = std::find_if(
+                map.begin(), map.end(), [&](const Reporters::value_type pair) {
+                    return StringUtils::toLower(pair.first) == candidateName;
+                });
+
+            if (iter != map.end())
+            {
+                return iter->first;
+            }
+        }
+
+        return std::string{};
+    }
+}
+
+// ******************** From: TextDiffReporter.cpp
+
+#include <iostream>
+
+namespace ApprovalTests
+{
+    TextDiffReporter::TextDiffReporter() : TextDiffReporter(std::cout)
+    {
+    }
+
+    TextDiffReporter::TextDiffReporter(std::ostream& stream) : stream_(stream)
+    {
+        std::vector<std::shared_ptr<Reporter>> reporters = {
+            CustomReporter::createForegroundReporter("diff", Type::TEXT, true),
+            CustomReporter::createForegroundReporter(
+                "C:/Windows/System32/fc.exe", Type::TEXT_AND_IMAGE, true)};
+        m_reporter = std::unique_ptr<Reporter>(new FirstWorkingReporter(reporters));
+    }
+
+    bool TextDiffReporter::report(std::string received, std::string approved) const
+    {
+        stream_ << "Comparing files:" << std::endl;
+        stream_ << "received: " << received << std::endl;
+        stream_ << "approved: " << approved << std::endl;
+        const bool result = m_reporter->report(received, approved);
+        if (!result)
+        {
+            stream_ << "TextDiffReporter did not find a working diff "
+                       "program\n\n";
+        }
+
+        return result;
+    }
+}
+
+// ******************** From: WindowsReporters.cpp
+
+
+namespace ApprovalTests
+{
+    namespace Windows
+    {
+        VisualStudioCodeReporter::VisualStudioCodeReporter()
+            : GenericDiffReporter(DiffPrograms::Windows::VS_CODE())
+        {
+        }
+
+        // ----------------------- Beyond Compare ----------------------------------
+        BeyondCompare3Reporter::BeyondCompare3Reporter()
+            : GenericDiffReporter(DiffPrograms::Windows::BEYOND_COMPARE_3())
+        {
+        }
+
+        BeyondCompare4Reporter::BeyondCompare4Reporter()
+            : GenericDiffReporter(DiffPrograms::Windows::BEYOND_COMPARE_4())
+        {
+        }
+
+        BeyondCompareReporter::BeyondCompareReporter()
+            : FirstWorkingReporter(
+                  {new BeyondCompare4Reporter(), new BeyondCompare3Reporter()})
+        {
+        }
+
+        // ----------------------- Tortoise SVN ------------------------------------
+        TortoiseImageDiffReporter::TortoiseImageDiffReporter()
+            : GenericDiffReporter(DiffPrograms::Windows::TORTOISE_IMAGE_DIFF())
+        {
+        }
+
+        TortoiseTextDiffReporter::TortoiseTextDiffReporter()
+            : GenericDiffReporter(DiffPrograms::Windows::TORTOISE_TEXT_DIFF())
+        {
+        }
+
+        TortoiseDiffReporter::TortoiseDiffReporter()
+            : FirstWorkingReporter(
+                  {new TortoiseTextDiffReporter(), new TortoiseImageDiffReporter()})
+        {
+        }
+
+        // ----------------------- Tortoise Git ------------------------------------
+        TortoiseGitTextDiffReporter::TortoiseGitTextDiffReporter()
+            : GenericDiffReporter(DiffPrograms::Windows::TORTOISE_GIT_TEXT_DIFF())
+        {
+        }
+
+        TortoiseGitImageDiffReporter::TortoiseGitImageDiffReporter()
+            : GenericDiffReporter(DiffPrograms::Windows::TORTOISE_GIT_IMAGE_DIFF())
+        {
+        }
+
+        TortoiseGitDiffReporter::TortoiseGitDiffReporter()
+            : FirstWorkingReporter(
+                  {new TortoiseGitTextDiffReporter(), new TortoiseGitImageDiffReporter()})
+        {
+        }
+
+        // -------------------------------------------------------------------------
+        WinMergeReporter::WinMergeReporter()
+            : GenericDiffReporter(DiffPrograms::Windows::WIN_MERGE_REPORTER())
+        {
+        }
+
+        AraxisMergeReporter::AraxisMergeReporter()
+            : GenericDiffReporter(DiffPrograms::Windows::ARAXIS_MERGE())
+        {
+        }
+
+        CodeCompareReporter::CodeCompareReporter()
+            : GenericDiffReporter(DiffPrograms::Windows::CODE_COMPARE())
+        {
+        }
+
+        SublimeMergeReporter::SublimeMergeReporter()
+            : GenericDiffReporter(DiffPrograms::Windows::SUBLIME_MERGE())
+        {
+            launcher.setForeground(true);
+        }
+
+        KDiff3Reporter::KDiff3Reporter()
+            : GenericDiffReporter(DiffPrograms::Windows::KDIFF3())
+        {
+        }
+
+        WindowsDiffReporter::WindowsDiffReporter()
+            : FirstWorkingReporter({
+                  new TortoiseDiffReporter(), // Note that this uses Tortoise SVN Diff
+                  new TortoiseGitDiffReporter(),
+                  new BeyondCompareReporter(),
+                  new WinMergeReporter(),
+                  new AraxisMergeReporter(),
+                  new CodeCompareReporter(),
+                  new SublimeMergeReporter(),
+                  new KDiff3Reporter(),
+                  new VisualStudioCodeReporter(),
+              })
+        {
+        }
+
+        bool WindowsDiffReporter::report(std::string received, std::string approved) const
+        {
+            if (!SystemUtils::isWindowsOs())
+            {
+                return false;
+            }
+            return FirstWorkingReporter::report(received, approved);
+        }
+    }
+}
+
+// ******************** From: Scrubbers.cpp
+
+#include <string>
+#include <functional>
+#include <regex>
+#include <map>
+
+namespace ApprovalTests
+{
+    namespace Scrubbers
+    {
+        std::string doNothing(const std::string& input)
+        {
+            return input;
+        }
+        std::string scrubRegex(const std::string& input,
+                               const std::regex& regex,
+                               const RegexReplacer& replaceFunction)
+        {
+            std::string result;
+            std::string remainder = input;
+            std::smatch m;
+            while (std::regex_search(remainder, m, regex))
+            {
+                auto match = m[0];
+                auto original_matched_text = match.str();
+                auto replacement = replaceFunction(match);
+                result += std::string(m.prefix()) + replacement;
+                remainder = m.suffix();
+            }
+            result += remainder;
+            return result;
+        }
+
+        Scrubber createRegexScrubber(const std::regex& regexPattern,
+                                     const RegexReplacer& replacer)
+        {
+            return [=](const std::string& input) {
+                return scrubRegex(input, regexPattern, replacer);
+            };
+        }
+
+        Scrubber createRegexScrubber(const std::regex& regexPattern,
+                                     const std::string& replacementText)
+        {
+            return createRegexScrubber(
+                regexPattern, [=](const RegexMatch&) { return replacementText; });
+        }
+
+        Scrubber createRegexScrubber(const std::string& regexString,
+                                     const std::string& replacementText)
+        {
+            if (regexString.empty())
+            {
+                return doNothing;
+            }
+            return createRegexScrubber(std::regex(regexString), replacementText);
+        }
+
+        std::string scrubGuid(const std::string& input)
+        {
+            static const std::regex regex("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-["
+                                          "0-9a-fA-F]{4}-[0-9a-fA-F]{12}");
+
+            int matchNumber = 0;
+            std::map<std::string, int> matchIndices;
+            return scrubRegex(input, regex, [&](const RegexMatch& m) {
+                auto guid_match = m.str();
+
+                if (matchIndices[guid_match] == 0)
+                {
+                    matchIndices[guid_match] = ++matchNumber;
+                }
+                return "guid_" + std::to_string(matchIndices[guid_match]);
+            });
+        }
+    }
+}
+
+// ******************** From: DateUtils.cpp
+
+#include <sstream>
+#include <iomanip>
+
+namespace ApprovalTests
+{
+    std::tm
+    DateUtils::createTm(int year, int month, int day, int hour, int minute, int second)
+    {
+        std::tm timeinfo = tm();
+        timeinfo.tm_year = year - 1900;
+        timeinfo.tm_mon = month - 1;
+        timeinfo.tm_mday = day;
+        timeinfo.tm_hour = hour;
+        timeinfo.tm_min = minute;
+        timeinfo.tm_sec = second;
+        return timeinfo;
+    }
+
+    std::chrono::system_clock::time_point
+    DateUtils::createUtcDateTime(int year,
+                                 int month,
+                                 int day,
+                                 int hour,
+                                 int minute,
+                                 int second) // these are UTC values
+    {
+        tm timeinfo = createTm(year, month, day, hour, minute, second);
+        time_t tt = toUtc(timeinfo);
+        return std::chrono::system_clock::from_time_t(tt);
+    }
+
+    std::string DateUtils::toString(const std::chrono::system_clock::time_point& dateTime)
+    {
+        return toString(dateTime, "%a %Y-%m-%d %H:%M:%S UTC");
+    }
+
+    std::string DateUtils::toString(const std::chrono::system_clock::time_point& dateTime,
+                                    const std::string& format)
+    {
+        time_t tt = std::chrono::system_clock::to_time_t(dateTime);
+        tm tm_value = toUtc(tt);
+
+        return StringUtils::toString(std::put_time(&tm_value, format.c_str()));
+    }
+
+    time_t DateUtils::toUtc(std::tm& timeinfo)
+    {
+#ifdef _WIN32
+        std::time_t tt = _mkgmtime(&timeinfo);
+#else
+        time_t tt = timegm(&timeinfo);
+#endif
+        return tt;
+    }
+
+    tm DateUtils::toUtc(time_t& tt)
+    {
+#ifdef _MSC_VER // Visual Studio compiler
+        std::tm tm_value = {};
+        gmtime_s(&tm_value, &tt);
+#else
+        tm tm_value = *gmtime(&tt);
+#endif
+        return tm_value;
+    }
+}
+
+// ******************** From: EmptyFileCreatorByType.cpp
+
+namespace
+{
+    std::map<std::string, ApprovalTests::EmptyFileCreator>
+    defaultEmptyFileCreatorByTypeCreators()
+    {
+        std::map<std::string, ApprovalTests::EmptyFileCreator> creators;
+        ApprovalTests::EmptyFileCreator wibbleCreator = [](std::string fileName) {
+            ApprovalTests::StringWriter s("{}");
+            s.write(fileName);
+        };
+        creators[".json"] = wibbleCreator;
+        return creators;
+    }
+}
+
+namespace ApprovalTests
+{
+    std::map<std::string, ApprovalTests::EmptyFileCreator>
+        EmptyFileCreatorByType::creators_ = defaultEmptyFileCreatorByTypeCreators();
+
+    void EmptyFileCreatorByType::registerCreator(const std::string& extensionWithDot,
+                                                 EmptyFileCreator creator)
+    {
+        creators_[extensionWithDot] = std::move(creator);
+    }
+
+    void EmptyFileCreatorByType::createFile(const std::string& fileName)
+    {
+        for (const auto& creator : creators_)
+        {
+            if (StringUtils::endsWith(fileName, creator.first))
+            {
+                creator.second(fileName);
+                return;
+            }
+        }
+        EmptyFileCreatorFactory::defaultCreator(fileName);
+    }
+}
+
+// ******************** From: EmptyFileCreatorDisposer.cpp
+#include <sstream>
+
+namespace ApprovalTests
+{
+
+    EmptyFileCreatorDisposer::EmptyFileCreatorDisposer(EmptyFileCreator creator)
+    {
+        previous_result = std::move(EmptyFileCreatorFactory::currentCreator);
+        EmptyFileCreatorFactory::currentCreator = std::move(creator);
+    }
+
+    EmptyFileCreatorDisposer::~EmptyFileCreatorDisposer()
+    {
+        EmptyFileCreatorFactory::currentCreator = std::move(previous_result);
+    }
+}
+
+// ******************** From: EmptyFileCreatorFactory.cpp
+namespace ApprovalTests
+{
+
+    void EmptyFileCreatorFactory::defaultCreator(std::string fullFilePath)
+    {
+        StringWriter s("", "");
+        s.write(fullFilePath);
+    }
+
+    EmptyFileCreator EmptyFileCreatorFactory::currentCreator =
+        EmptyFileCreatorByType::createFile;
+}
+
+// ******************** From: ExceptionCollector.cpp
+
+namespace ApprovalTests
+{
+    void ExceptionCollector::gather(std::function<void(void)> functionThatThrows)
+    {
+        try
+        {
+            functionThatThrows();
+        }
+        catch (const std::exception& e)
+        {
+            exceptionMessages.emplace_back(e.what());
+        }
+    }
+
+    ExceptionCollector::~ExceptionCollector()
+    {
+        if (!exceptionMessages.empty())
+        {
+            exceptionMessages.emplace_back("ERROR: Calling code forgot to call "
+                                           "exceptionCollector.release()");
+        }
+        release();
+    }
+
+    void ExceptionCollector::release()
+    {
+        if (!exceptionMessages.empty())
+        {
+            std::stringstream s;
+            s << exceptionMessages.size() << " exceptions were thrown:\n\n";
+            int count = 1;
+            for (const auto& error : exceptionMessages)
+            {
+                s << count++ << ") " << error << '\n';
+            }
+            exceptionMessages.clear();
+            throw std::runtime_error(s.str());
+        }
+    }
+}
+
+// ******************** From: FileUtils.cpp
+
+#include <fstream>
+#include <sys/stat.h>
+#include <sstream>
+
+namespace ApprovalTests
+{
+    bool FileUtils::fileExists(const std::string& path)
+    {
+        struct stat info
+        {
+        };
+        return stat(path.c_str(), &info) == 0;
+    }
+
+    int FileUtils::fileSize(const std::string& path)
+    {
+        struct stat statbuf
+        {
+        };
+        int stat_ok = stat(path.c_str(), &statbuf);
+
+        if (stat_ok == -1)
+        {
+            return -1;
+        }
+
+        return int(statbuf.st_size);
+    }
+
+    EmptyFileCreatorDisposer FileUtils::useEmptyFileCreator(EmptyFileCreator creator)
+    {
+        return EmptyFileCreatorDisposer(creator);
+    }
+
+    void FileUtils::ensureFileExists(const std::string& fullFilePath)
+    {
+        if (!fileExists(fullFilePath))
+        {
+            EmptyFileCreatorFactory::currentCreator(fullFilePath);
+        }
+    }
+
+    std::string FileUtils::getDirectory(const std::string& filePath)
+    {
+        auto end = filePath.rfind(SystemUtils::getDirectorySeparator()) + 1;
+        auto directory = filePath.substr(0, end);
+        return directory;
+    }
+
+    std::string FileUtils::getExtensionWithDot(const std::string& filePath)
+    {
+        std::size_t found = filePath.find_last_of('.');
+        return filePath.substr(found);
+    }
+
+    std::string FileUtils::readFileThrowIfMissing(const std::string& fileName)
+    {
+        std::ifstream in(fileName.c_str(), std::ios_base::in);
+        if (!in)
+        {
+            throw std::runtime_error("File does not exist: " + fileName);
+        }
+        std::stringstream written;
+        written << in.rdbuf();
+        in.close();
+
+        std::string text = written.str();
+        return text;
+    }
+
+    std::string FileUtils::readFileReturnEmptyIfMissing(const std::string& fileName)
+    {
+        if (FileUtils::fileExists(fileName))
+        {
+            return readFileThrowIfMissing(fileName);
+        }
+        else
+        {
+            return std::string();
+        }
+    }
+
+    void FileUtils::writeToFile(const std::string& filePath, const std::string& content)
+    {
+        std::ofstream out(filePath.c_str(), std::ios::binary | std::ofstream::out);
+        if (!out)
+        {
+            throw std::runtime_error("Unable to write file: " + filePath);
+        }
+        out << content;
+    }
+
+}
+
+// ******************** From: FileUtilsSystemSpecific.cpp
+
+namespace ApprovalTests
+{
+    std::string FileUtilsSystemSpecific::getCommandLineForCopy(
+        const std::string& source, const std::string& destination, bool isWindows)
+    {
+        if (isWindows)
+        {
+            return std::string("copy /Y ") + "\"" + source + "\" \"" + destination + "\"";
+        }
+        else
+        {
+            return std::string("cp ") + "\"" + source + "\" \"" + destination + "\"";
+        }
+    }
+
+    void FileUtilsSystemSpecific::copyFile(const std::string& source,
+                                           const std::string& destination)
+    {
+        auto cmd = getCommandLineForCopy(source, destination, SystemUtils::isWindowsOs());
+        SystemUtils::runSystemCommandOrThrow(cmd);
+    }
+}
+
+// ******************** From: Grid.cpp
+namespace ApprovalTests
+{
+    std::string Grid::print(int width,
+                            int height,
+                            std::function<void(int, int, std::ostream&)> printCell)
+    {
+        std::stringstream s;
+        for (int y = 0; y < height; ++y)
+        {
+            for (int x = 0; x < width; ++x)
+            {
+                printCell(x, y, s);
+            }
+            s << '\n';
+        }
+        return s.str();
+    }
+    std::string Grid::print(int width, int height, std::string text)
+    {
+        return print(
+            width, height, [&](int /*x*/, int /*y*/, std::ostream& os) { os << text; });
+    }
+}
+
+// ******************** From: MachineBlocker.cpp
+
+namespace ApprovalTests
+{
+    MachineBlocker::MachineBlocker(std::string machineName_, bool block_)
+        : machineName(std::move(machineName_)), block(block_)
+    {
+    }
+
+    MachineBlocker MachineBlocker::onMachineNamed(const std::string& machineName)
+    {
+        return MachineBlocker(machineName, true);
+    }
+
+    MachineBlocker MachineBlocker::onMachinesNotNamed(const std::string& machineName)
+    {
+        return MachineBlocker(machineName, false);
+    }
+
+    bool MachineBlocker::isBlockingOnThisMachine() const
+    {
+        const auto isMachine = (SystemUtils::getMachineName() == machineName);
+        return isMachine == block;
+    }
+}
+
+// ******************** From: MoreHelpMessages.cpp
+
+#include <iostream>
+
+namespace ApprovalTests
+{
+    void MoreHelpMessages::deprecatedFunctionCalled(const std::string& message,
+                                                    const std::string& file,
+                                                    int lineNumber)
+    {
+        std::cout << "\n***************** Deprecation Warning: ***************\n"
+                  << "*\n"
+                  << "* " << message << '\n'
+                  << "*\n"
+                  << "* Deprecated method:\n"
+                  << "*    " << file << ":" << lineNumber << '\n'
+                  << "* Called from:\n"
+                  << "*    " << ApprovalTestNamer::getCurrentTest().getFileName() << '\n'
+                  << "*\n"
+                  << "******************************************************\n\n";
+    }
+}
+
+// ******************** From: Path.cpp
+
+namespace ApprovalTests
+{
+
+    Path::Path(const std::string& start) : path_(normalizeSeparators(start))
+    {
+    }
+
+    std::string Path::toString() const
+    {
+        return toString(separator_);
+    }
+
+    std::string Path::toString(const std::string& directoryPathSeparator) const
+    {
+        std::string path = removeRedundantDirectorySeparators(path_);
+
+        if (separator_ == directoryPathSeparator)
+        {
+            return path;
+        }
+        return StringUtils::replaceAll(path, separator_, directoryPathSeparator);
+    }
+
+    std::string Path::removeRedundantDirectorySeparators(std::string path) const
+    {
+        bool changed = true;
+        while (changed)
+        {
+            std::string reducePath = path;
+            reducePath = StringUtils::replaceAll(reducePath, "//", "/");
+            reducePath = StringUtils::replaceAll(reducePath, "\\\\", "\\");
+            changed = (reducePath != path);
+            path = reducePath;
+        };
+        return path;
+    }
+
+    Path Path::operator+(const std::string& addition) const
+    {
+        return Path(path_ + addition);
+    }
+
+    Path Path::operator/(const std::string& addition) const
+    {
+        auto first = path_;
+        if (StringUtils::endsWith(first, separator_))
+        {
+            first = first.substr(0, path_.size() - 1);
+        }
+
+        auto second = addition;
+        if (StringUtils::beginsWith(second, separator_))
+        {
+            second = second.substr(1);
+        }
+
+        return Path(first + separator_ + second);
+    }
+
+    Path Path::operator/(const Path addition) const
+    {
+        return *this / addition.path_;
+    }
+
+    std::string Path::normalizeSeparators(const std::string& path)
+    {
+        auto separator = SystemUtils::getDirectorySeparator();
+        auto otherSeparator = (separator == "/" ? "\\" : "/");
+        return StringUtils::replaceAll(path, otherSeparator, separator);
+    }
+}
+
+// ******************** From: StringUtils.cpp
+
+#include <cctype>
+
+namespace ApprovalTests
+{
+    APPROVAL_TESTS_NO_DISCARD
+    std::string StringUtils::replaceAll(std::string inText,
+                                        const std::string& find,
+                                        const std::string& replaceWith)
+    {
+        size_t start_pos = 0;
+        while ((start_pos = inText.find(find, start_pos)) != std::string::npos)
+        {
+            inText.replace(start_pos, find.length(), replaceWith);
+            start_pos +=
+                replaceWith.length(); // Handles case where 'to' is a substring of 'from'
+        }
+        return inText;
+    }
+
+    APPROVAL_TESTS_NO_DISCARD
+    bool StringUtils::contains(const std::string& inText, const std::string& find)
+    {
+        return inText.find(find, 0) != std::string::npos;
+    }
+
+    APPROVAL_TESTS_NO_DISCARD
+    std::string StringUtils::toLower(std::string inText)
+    {
+        std::string copy(inText);
+        std::transform(inText.begin(), inText.end(), copy.begin(), [](char c) {
+            return static_cast<char>(tolower(c));
+        });
+        return copy;
+    }
+
+    APPROVAL_TESTS_NO_DISCARD
+    bool StringUtils::beginsWith(std::string value, std::string beginning)
+    {
+        if (value.size() < beginning.size())
+        {
+            return false;
+        }
+        return std::equal(beginning.begin(), beginning.end(), value.begin());
+    }
+
+    APPROVAL_TESTS_NO_DISCARD
+    bool StringUtils::endsWith(std::string value, std::string ending)
+    {
+        if (value.size() < ending.size())
+        {
+            return false;
+        }
+        return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
+    }
+
+    APPROVAL_TESTS_NO_DISCARD
+    std::string StringUtils::leftTrim(std::string s)
+    {
+
+        s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
+                    return !std::isspace(ch);
+                }));
+        return s;
+    }
+
+    APPROVAL_TESTS_NO_DISCARD
+    std::string StringUtils::rightTrim(std::string s)
+    {
+        s.erase(std::find_if(s.rbegin(),
+                             s.rend(),
+                             [](unsigned char ch) { return !std::isspace(ch); })
+                    .base(),
+                s.end());
+        return s;
+    }
+
+    APPROVAL_TESTS_NO_DISCARD
+    std::string StringUtils::trim(std::string s)
+    {
+        s = leftTrim(s);
+        s = rightTrim(s);
+        return s;
+    }
+}
+
+// ******************** From: SystemUtils.cpp
+
+#include <sys/stat.h>
+
+namespace ApprovalTests
+{
+    bool SystemUtils::isWindowsOs()
+    {
+#ifdef _WIN32
+        return true;
+#else
+        return false;
+#endif
+    }
+
+    bool SystemUtils::isCygwin()
+    {
+#ifdef __CYGWIN__
+        return true;
+#else
+        return false;
+#endif
+    }
+
+    bool SystemUtils::isMacOs()
+    {
+#ifdef __APPLE__
+        return true;
+#else
+        return false;
+#endif
+    }
+    std::string SystemUtils::getDirectorySeparator()
+    {
+        return isWindowsOs() ? "\\" : "/";
+    }
+
+    std::string SystemUtils::checkFilenameCase(const std::string& fullPath)
+    {
+        if (!isWindowsOs() || !FileUtils::fileExists(fullPath))
+        {
+            return fullPath;
+        }
+#ifdef _WIN32
+
+        _finddata_t findFileData;
+        auto hFind = _findfirst(fullPath.c_str(), &findFileData);
+
+        if (hFind != -1)
+        {
+            const std::string fixedFilename = findFileData.name;
+            const std::string fixedPath = StringUtils::replaceAll(
+                fullPath, StringUtils::toLower(fixedFilename), fixedFilename);
+            _findclose(hFind);
+            return fixedPath;
+        }
+
+#endif
+        return fullPath;
+    }
+
+    std::string SystemUtils::safeGetEnvForWindows(const char* name)
+    {
+        APPROVAL_TESTS_UNUSED(name);
+#ifdef _WIN32
+        // We use getenv_s on Windows, as use of getenv there gives:
+        //      warning C4996: 'getenv': This function or variable may be unsafe. Consider using _dupenv_s instead.
+        //      To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
+
+        size_t size;
+        getenv_s(&size, nullptr, 0, name);
+
+        if (size != 0)
+        {
+            std::string result;
+            result.resize(size);
+            getenv_s(&size, &*result.begin(), size, name);
+            result.pop_back();
+            return result;
+        }
+#endif
+        return std::string();
+    }
+
+    std::string SystemUtils::safeGetEnvForNonWindows(const char* name)
+    {
+        APPROVAL_TESTS_UNUSED(name);
+        char* p = nullptr;
+#ifndef _WIN32
+        p = getenv(name);
+#endif
+        return (p != nullptr) ? p : std::string();
+    }
+
+    std::string SystemUtils::safeGetEnv(const char* name)
+    {
+        return isWindowsOs() ? safeGetEnvForWindows(name) : safeGetEnvForNonWindows(name);
+    }
+
+    std::string SystemUtils::getMachineName()
+    {
+        auto name = safeGetEnv("COMPUTERNAME");
+        if (!name.empty())
+        {
+            return name;
+        }
+
+        name = safeGetEnv("HOSTNAME");
+        if (!name.empty())
+        {
+            return name;
+        }
+
+        return "Unknown Computer";
+    }
+
+    void SystemUtils::makeDirectoryForWindows(const std::string& directory)
+    {
+        APPROVAL_TESTS_UNUSED(directory);
+#ifdef _WIN32
+        int nError = _mkdir(directory.c_str());
+        if (nError != 0)
+        {
+            std::string helpMessage =
+                std::string("Unable to create directory: ") + directory;
+            throw std::runtime_error(helpMessage);
+        }
+#endif
+    }
+
+    void SystemUtils::makeDirectoryForNonWindows(const std::string& directory)
+    {
+        APPROVAL_TESTS_UNUSED(directory);
+#ifndef _WIN32
+        mode_t nMode = 0733; // UNIX style permissions
+        int nError = mkdir(directory.c_str(), nMode);
+        if (nError != 0)
+        {
+            std::string helpMessage =
+                std::string("Unable to create directory: ") + directory;
+            throw std::runtime_error(helpMessage);
+        }
+#endif
+    }
+
+    void SystemUtils::makeDirectory(const std::string& directory)
+    {
+        makeDirectoryForWindows(directory);
+        makeDirectoryForNonWindows(directory);
+    }
+
+    void SystemUtils::ensureDirectoryExists(const std::string& fullDirectoryPath)
+    {
+        if (!FileUtils::fileExists(fullDirectoryPath))
+        {
+            makeDirectory(fullDirectoryPath);
+        }
+    }
+
+    void SystemUtils::ensureParentDirectoryExists(const std::string& fullFilePath)
+    {
+        const std::string parentDirectory = FileUtils::getDirectory(fullFilePath);
+        if (!parentDirectory.empty())
+        {
+            SystemUtils::ensureDirectoryExists(parentDirectory);
+        }
+    }
+
+    void SystemUtils::runSystemCommandOrThrow(const std::string& command,
+                                              bool allowNonZeroExitCodes)
+    {
+        int exitCode = system(command.c_str());
+
+        if (!allowNonZeroExitCodes && exitCode != 0)
+        {
+            throw std::runtime_error(command + ": failed with exit code " +
+                                     std::to_string(exitCode));
+        }
+    }
+}
+
+// ******************** From: ExistingFile.cpp
+
+namespace ApprovalTests
+{
+    std::string ExistingFile::scrub(std::string fileName, const Options& options)
+    {
+        if (options.isUsingDefaultScrubber())
+        {
+            return fileName;
+        }
+        auto content = FileUtils::readFileThrowIfMissing(fileName);
+        const auto scrubbedContent = options.scrub(content);
+        if (content == scrubbedContent)
+        {
+            deleteScrubbedFile = false;
+            return fileName;
+        }
+        else
+        {
+            std::size_t found = fileName.find_last_of('.');
+            auto fileExtension = fileName.substr(found);
+            std::string baseName = fileName.substr(0, found);
+
+            auto newFileName = baseName + ".scrubbed.received" + fileExtension;
+            FileUtils::writeToFile(newFileName, scrubbedContent);
+            deleteScrubbedFile = true;
+            return newFileName;
+        }
+    }
+
+    ExistingFile::ExistingFile(std::string filePath_, const Options& options)
+        : options_(options)
+    {
+        filePath = scrub(filePath_, options);
+    }
+
+    std::string ExistingFile::getFileExtensionWithDot() const
+    {
+        return FileUtils::getExtensionWithDot(filePath);
+    }
+
+    void ExistingFile::write(std::string) const
+    {
+        // do nothing
+    }
+
+    void ExistingFile::cleanUpReceived(std::string receivedPath) const
+    {
+        if (deleteScrubbedFile && (receivedPath == filePath))
+        {
+            remove(receivedPath.c_str());
+        }
+    }
+
+    ExistingFileNamer ExistingFile::getNamer()
+    {
+        return ExistingFileNamer(filePath, options_);
+    }
+}
+
+// ******************** From: StringWriter.cpp
+
+#include <utility>
+#include <fstream>
+
+namespace ApprovalTests
+{
+    StringWriter::StringWriter(std::string contents, std::string fileExtensionWithDot)
+        : s(std::move(contents)), ext(std::move(fileExtensionWithDot))
+    {
+    }
+
+    std::string StringWriter::getFileExtensionWithDot() const
+    {
+        return ext;
+    }
+
+    void StringWriter::write(std::string path) const
+    {
+        std::ofstream out(path.c_str(), std::ofstream::out);
+        if (!out)
+        {
+            throw std::runtime_error("Unable to write file: " + path);
+        }
+        this->Write(out);
+        out.close();
+    }
+
+    void StringWriter::Write(std::ostream& out) const
+    {
+        out << s << "\n";
+    }
+
+    void StringWriter::cleanUpReceived(std::string receivedPath) const
+    {
+        remove(receivedPath.c_str());
+    }
+}
+#endif // APPROVAL_TESTS_INCLUDE_CPPS
+
+#endif // APPROVAL_TESTS_CPP_APPROVALS_HPP

--- a/cpp/third_party/doctest/doctest.h
+++ b/cpp/third_party/doctest/doctest.h
@@ -4,14 +4,14 @@
 //
 // doctest.h - the lightest feature-rich C++ single-header testing framework for unit tests and TDD
 //
-// Copyright (c) 2016-2019 Viktor Kirilov
+// Copyright (c) 2016-2021 Viktor Kirilov
 //
 // Distributed under the MIT Software License
 // See accompanying file LICENSE.txt or copy at
 // https://opensource.org/licenses/MIT
 //
 // The documentation can be found at the library's page:
-// https://github.com/onqtam/doctest/blob/master/doc/markdown/readme.md
+// https://github.com/doctest/doctest/blob/master/doc/markdown/readme.md
 //
 // =================================================================================================
 // =================================================================================================
@@ -47,9 +47,17 @@
 // =================================================================================================
 
 #define DOCTEST_VERSION_MAJOR 2
-#define DOCTEST_VERSION_MINOR 3
-#define DOCTEST_VERSION_PATCH 4
-#define DOCTEST_VERSION_STR "2.3.4"
+#define DOCTEST_VERSION_MINOR 4
+#define DOCTEST_VERSION_PATCH 9
+
+// util we need here
+#define DOCTEST_TOSTR_IMPL(x) #x
+#define DOCTEST_TOSTR(x) DOCTEST_TOSTR_IMPL(x)
+
+#define DOCTEST_VERSION_STR                                                                        \
+    DOCTEST_TOSTR(DOCTEST_VERSION_MAJOR) "."                                                       \
+    DOCTEST_TOSTR(DOCTEST_VERSION_MINOR) "."                                                       \
+    DOCTEST_TOSTR(DOCTEST_VERSION_PATCH)
 
 #define DOCTEST_VERSION                                                                            \
     (DOCTEST_VERSION_MAJOR * 10000 + DOCTEST_VERSION_MINOR * 100 + DOCTEST_VERSION_PATCH)
@@ -59,6 +67,12 @@
 // =================================================================================================
 
 // ideas for the version stuff are taken from here: https://github.com/cxxstuff/cxx_detect
+
+#ifdef _MSC_VER
+#define DOCTEST_CPLUSPLUS _MSVC_LANG
+#else
+#define DOCTEST_CPLUSPLUS __cplusplus
+#endif
 
 #define DOCTEST_COMPILER(MAJOR, MINOR, PATCH) ((MAJOR)*10000000 + (MINOR)*100000 + (PATCH))
 
@@ -137,84 +151,92 @@
 // == COMPILER WARNINGS ============================================================================
 // =================================================================================================
 
+// both the header and the implementation suppress all of these,
+// so it only makes sense to aggregrate them like so
+#define DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH                                                      \
+    DOCTEST_CLANG_SUPPRESS_WARNING_PUSH                                                            \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-pragmas")                                            \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wweak-vtables")                                               \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wpadded")                                                     \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")                                         \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat")                                               \
+    DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")                                      \
+                                                                                                   \
+    DOCTEST_GCC_SUPPRESS_WARNING_PUSH                                                              \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wunknown-pragmas")                                              \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wpragmas")                                                      \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Weffc++")                                                       \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-overflow")                                              \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-aliasing")                                              \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-declarations")                                         \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wuseless-cast")                                                 \
+    DOCTEST_GCC_SUPPRESS_WARNING("-Wnoexcept")                                                     \
+                                                                                                   \
+    DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                                                             \
+    /* these 4 also disabled globally via cmake: */                                                \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4514) /* unreferenced inline function has been removed */        \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4571) /* SEH related */                                          \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4710) /* function not inlined */                                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4711) /* function selected for inline expansion*/                \
+    /* */                                                                                          \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4616) /* invalid compiler warning */                             \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4619) /* invalid compiler warning */                             \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4996) /* The compiler encountered a deprecated declaration */    \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4706) /* assignment within conditional expression */             \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4512) /* 'class' : assignment operator could not be generated */ \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4127) /* conditional expression is constant */                   \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4820) /* padding */                                              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4625) /* copy constructor was implicitly deleted */              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4626) /* assignment operator was implicitly deleted */           \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5027) /* move assignment operator implicitly deleted */          \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5026) /* move constructor was implicitly deleted */              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4640) /* construction of local static object not thread-safe */  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                   \
+    /* static analysis */                                                                          \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26439) /* Function may not throw. Declare it 'noexcept' */       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26495) /* Always initialize a member variable */                 \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26451) /* Arithmetic overflow ... */                             \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26444) /* Avoid unnamed objects with custom ctor and dtor... */  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(26812) /* Prefer 'enum class' over 'enum' */
+
+#define DOCTEST_SUPPRESS_COMMON_WARNINGS_POP                                                       \
+    DOCTEST_CLANG_SUPPRESS_WARNING_POP                                                             \
+    DOCTEST_GCC_SUPPRESS_WARNING_POP                                                               \
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH
+
 DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-pragmas")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wnon-virtual-dtor")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wweak-vtables")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wpadded")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wdeprecated")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-local-typedef")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")
 
 DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-DOCTEST_GCC_SUPPRESS_WARNING("-Wunknown-pragmas")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wpragmas")
-DOCTEST_GCC_SUPPRESS_WARNING("-Weffc++")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-overflow")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-aliasing")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wctor-dtor-privacy")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-declarations")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wnon-virtual-dtor")
-DOCTEST_GCC_SUPPRESS_WARNING("-Winline")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wunused-local-typedefs")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wuseless-cast")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wnoexcept")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-promo")
 
 DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-DOCTEST_MSVC_SUPPRESS_WARNING(4616) // invalid compiler warning
-DOCTEST_MSVC_SUPPRESS_WARNING(4619) // invalid compiler warning
-DOCTEST_MSVC_SUPPRESS_WARNING(4996) // The compiler encountered a deprecated declaration
-DOCTEST_MSVC_SUPPRESS_WARNING(4706) // assignment within conditional expression
-DOCTEST_MSVC_SUPPRESS_WARNING(4512) // 'class' : assignment operator could not be generated
-DOCTEST_MSVC_SUPPRESS_WARNING(4127) // conditional expression is constant
-DOCTEST_MSVC_SUPPRESS_WARNING(4820) // padding
-DOCTEST_MSVC_SUPPRESS_WARNING(4625) // copy constructor was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(4626) // assignment operator was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(5027) // move assignment operator was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(5026) // move constructor was implicitly defined as deleted
 DOCTEST_MSVC_SUPPRESS_WARNING(4623) // default constructor was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is not thread-safe
-// static analysis
-DOCTEST_MSVC_SUPPRESS_WARNING(26439) // This kind of function may not throw. Declare it 'noexcept'
-DOCTEST_MSVC_SUPPRESS_WARNING(26495) // Always initialize a member variable
-DOCTEST_MSVC_SUPPRESS_WARNING(26451) // Arithmetic overflow ...
-DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom construction and dtr...
-
-// 4548 - expression before comma has no effect; expected expression with side - effect
-// 4265 - class has virtual functions, but destructor is not virtual
-// 4986 - exception specification does not match previous declaration
-// 4350 - behavior change: 'member1' called instead of 'member2'
-// 4668 - 'x' is not defined as a preprocessor macro, replacing with '0' for '#if/#elif'
-// 4365 - conversion from 'int' to 'unsigned long', signed/unsigned mismatch
-// 4774 - format string expected in argument 'x' is not a string literal
-// 4820 - padding in structs
-
-// only 4 should be disabled globally:
-// - 4514 # unreferenced inline function has been removed
-// - 4571 # SEH related
-// - 4710 # function not inlined
-// - 4711 # function 'x' selected for automatic inline expansion
 
 #define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN                                 \
     DOCTEST_MSVC_SUPPRESS_WARNING_PUSH                                                             \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4548)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4265)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4986)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4350)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4668)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4365)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4774)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4820)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4625)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4626)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5027)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5026)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(4623)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5039)                                                            \
-    DOCTEST_MSVC_SUPPRESS_WARNING(5045)
+    DOCTEST_MSVC_SUPPRESS_WARNING(4548) /* before comma no effect; expected side - effect */       \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4265) /* virtual functions, but destructor is not virtual */     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4986) /* exception specification does not match previous */      \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4350) /* 'member1' called instead of 'member2' */                \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4668) /* not defined as a preprocessor macro */                  \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4365) /* signed/unsigned mismatch */                             \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4774) /* format string not a string literal */                   \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4820) /* padding */                                              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4625) /* copy constructor was implicitly deleted */              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4626) /* assignment operator was implicitly deleted */           \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5027) /* move assignment operator implicitly deleted */          \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5026) /* move constructor was implicitly deleted */              \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4623) /* default constructor was implicitly deleted */           \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5039) /* pointer to pot. throwing function passed to extern C */ \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5045) /* Spectre mitigation for memory load */                   \
+    DOCTEST_MSVC_SUPPRESS_WARNING(5105) /* macro producing 'defined' has undefined behavior */     \
+    DOCTEST_MSVC_SUPPRESS_WARNING(4738) /* storing float result in memory, loss of performance */
 
 #define DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
@@ -227,6 +249,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 // GCC C++11 feature support table: https://gcc.gnu.org/projects/cxx-status.html
 // MSVC version table:
 // https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering
+// MSVC++ 14.3 (17) _MSC_VER == 1930 (Visual Studio 2022)
 // MSVC++ 14.2 (16) _MSC_VER == 1920 (Visual Studio 2019)
 // MSVC++ 14.1 (15) _MSC_VER == 1910 (Visual Studio 2017)
 // MSVC++ 14.0      _MSC_VER == 1900 (Visual Studio 2015)
@@ -236,6 +259,10 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 // MSVC++ 9.0       _MSC_VER == 1500 (Visual Studio 2008)
 // MSVC++ 8.0       _MSC_VER == 1400 (Visual Studio 2005)
 
+// Universal Windows Platform support
+#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
+#define DOCTEST_CONFIG_NO_WINDOWS_SEH
+#endif // WINAPI_FAMILY
 #if DOCTEST_MSVC && !defined(DOCTEST_CONFIG_WINDOWS_SEH)
 #define DOCTEST_CONFIG_WINDOWS_SEH
 #endif // MSVC
@@ -244,7 +271,7 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 #endif // DOCTEST_CONFIG_NO_WINDOWS_SEH
 
 #if !defined(_WIN32) && !defined(__QNX__) && !defined(DOCTEST_CONFIG_POSIX_SIGNALS) &&             \
-        !defined(__EMSCRIPTEN__)
+        !defined(__EMSCRIPTEN__) && !defined(__wasi__)
 #define DOCTEST_CONFIG_POSIX_SIGNALS
 #endif // _WIN32
 #if defined(DOCTEST_CONFIG_NO_POSIX_SIGNALS) && defined(DOCTEST_CONFIG_POSIX_SIGNALS)
@@ -252,7 +279,8 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 #endif // DOCTEST_CONFIG_NO_POSIX_SIGNALS
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-#if !defined(__cpp_exceptions) && !defined(__EXCEPTIONS) && !defined(_CPPUNWIND)
+#if !defined(__cpp_exceptions) && !defined(__EXCEPTIONS) && !defined(_CPPUNWIND)                   \
+        || defined(__wasi__)
 #define DOCTEST_CONFIG_NO_EXCEPTIONS
 #endif // no exceptions
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
@@ -266,6 +294,10 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 #if defined(DOCTEST_CONFIG_NO_EXCEPTIONS) && !defined(DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS)
 #define DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS && !DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
+
+#ifdef __wasi__
+#define DOCTEST_CONFIG_NO_MULTITHREADING
+#endif
 
 #if defined(DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN) && !defined(DOCTEST_CONFIG_IMPLEMENT)
 #define DOCTEST_CONFIG_IMPLEMENT
@@ -294,25 +326,72 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 #define DOCTEST_INTERFACE
 #endif // DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
 
+// needed for extern template instantiations
+// see https://github.com/fmtlib/fmt/issues/2228
+#if DOCTEST_MSVC
+#define DOCTEST_INTERFACE_DECL
+#define DOCTEST_INTERFACE_DEF DOCTEST_INTERFACE
+#else // DOCTEST_MSVC
+#define DOCTEST_INTERFACE_DECL DOCTEST_INTERFACE
+#define DOCTEST_INTERFACE_DEF
+#endif // DOCTEST_MSVC
+
 #define DOCTEST_EMPTY
 
 #if DOCTEST_MSVC
 #define DOCTEST_NOINLINE __declspec(noinline)
 #define DOCTEST_UNUSED
 #define DOCTEST_ALIGNMENT(x)
-#else // MSVC
+#elif DOCTEST_CLANG && DOCTEST_CLANG < DOCTEST_COMPILER(3, 5, 0)
+#define DOCTEST_NOINLINE
+#define DOCTEST_UNUSED
+#define DOCTEST_ALIGNMENT(x)
+#else
 #define DOCTEST_NOINLINE __attribute__((noinline))
 #define DOCTEST_UNUSED __attribute__((unused))
 #define DOCTEST_ALIGNMENT(x) __attribute__((aligned(x)))
-#endif // MSVC
+#endif
 
-#ifndef DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK
-#define DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK 5
-#endif // DOCTEST_CONFIG_NUM_CAPTURES_ON_STACK
+#ifndef DOCTEST_NORETURN
+#if DOCTEST_MSVC && (DOCTEST_MSVC < DOCTEST_COMPILER(19, 0, 0))
+#define DOCTEST_NORETURN
+#else // DOCTEST_MSVC
+#define DOCTEST_NORETURN [[noreturn]]
+#endif // DOCTEST_MSVC
+#endif // DOCTEST_NORETURN
+
+#ifndef DOCTEST_NOEXCEPT
+#if DOCTEST_MSVC && (DOCTEST_MSVC < DOCTEST_COMPILER(19, 0, 0))
+#define DOCTEST_NOEXCEPT
+#else // DOCTEST_MSVC
+#define DOCTEST_NOEXCEPT noexcept
+#endif // DOCTEST_MSVC
+#endif // DOCTEST_NOEXCEPT
+
+#ifndef DOCTEST_CONSTEXPR
+#if DOCTEST_MSVC && (DOCTEST_MSVC < DOCTEST_COMPILER(19, 0, 0))
+#define DOCTEST_CONSTEXPR const
+#define DOCTEST_CONSTEXPR_FUNC inline
+#else // DOCTEST_MSVC
+#define DOCTEST_CONSTEXPR constexpr
+#define DOCTEST_CONSTEXPR_FUNC constexpr
+#endif // DOCTEST_MSVC
+#endif // DOCTEST_CONSTEXPR
 
 // =================================================================================================
 // == FEATURE DETECTION END ========================================================================
 // =================================================================================================
+
+#define DOCTEST_DECLARE_INTERFACE(name)                                                            \
+    virtual ~name();                                                                               \
+    name() = default;                                                                              \
+    name(const name&) = delete;                                                                    \
+    name(name&&) = delete;                                                                         \
+    name& operator=(const name&) = delete;                                                         \
+    name& operator=(name&&) = delete;
+
+#define DOCTEST_DEFINE_INTERFACE(name)                                                             \
+    name::~name() = default;
 
 // internal macros for string concatenation and anonymous variable name generation
 #define DOCTEST_CAT_IMPL(s1, s2) s1##s2
@@ -322,8 +401,6 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 #else // __COUNTER__
 #define DOCTEST_ANONYMOUS(x) DOCTEST_CAT(x, __LINE__)
 #endif // __COUNTER__
-
-#define DOCTEST_TOSTR(x) #x
 
 #ifndef DOCTEST_CONFIG_ASSERTION_PARAMETERS_BY_VALUE
 #define DOCTEST_REF_WRAP(x) x&
@@ -338,27 +415,40 @@ DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom constr
 #define DOCTEST_PLATFORM_IPHONE
 #elif defined(_WIN32)
 #define DOCTEST_PLATFORM_WINDOWS
+#elif defined(__wasi__)
+#define DOCTEST_PLATFORM_WASI
 #else // DOCTEST_PLATFORM
 #define DOCTEST_PLATFORM_LINUX
 #endif // DOCTEST_PLATFORM
 
-// clang-format off
-#define DOCTEST_DELETE_COPIES(type)     type(const type&) = delete; type& operator=(const type&) = delete
-#define DOCTEST_DECLARE_COPIES(type)    type(const type&); type& operator=(const type&)
-#define DOCTEST_DEFINE_COPIES(type)     type::type(const type&) = default; type& type::operator=(const type&) = default
-#define DOCTEST_DECLARE_DEFAULTS(type)  type(); ~type()
-#define DOCTEST_DEFINE_DEFAULTS(type)   type::type()  = default; type::~type() = default
-// clang-format on
+namespace doctest { namespace detail {
+    static DOCTEST_CONSTEXPR int consume(const int*, int) noexcept { return 0; }
+}}
 
-#define DOCTEST_GLOBAL_NO_WARNINGS(var)                                                            \
-    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wglobal-constructors")                              \
-    DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-variable")                                            \
-    static int var DOCTEST_UNUSED // NOLINT(fuchsia-statically-constructed-objects,cert-err58-cpp)
-#define DOCTEST_GLOBAL_NO_WARNINGS_END() DOCTEST_CLANG_SUPPRESS_WARNING_POP
+#define DOCTEST_GLOBAL_NO_WARNINGS(var, ...)                                                         \
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wglobal-constructors")                                \
+    static const int var = doctest::detail::consume(&var, __VA_ARGS__);                              \
+    DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
+#ifndef DOCTEST_BREAK_INTO_DEBUGGER
 // should probably take a look at https://github.com/scottt/debugbreak
-#ifdef DOCTEST_PLATFORM_MAC
-#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :)
+#ifdef DOCTEST_PLATFORM_LINUX
+#if defined(__GNUC__) && (defined(__i386) || defined(__x86_64))
+// Break at the location of the failing check if possible
+#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :) // NOLINT(hicpp-no-assembler)
+#else
+#include <signal.h>
+#define DOCTEST_BREAK_INTO_DEBUGGER() raise(SIGTRAP)
+#endif
+#elif defined(DOCTEST_PLATFORM_MAC)
+#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386)
+#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("int $3\n" : :) // NOLINT(hicpp-no-assembler)
+#elif defined(__ppc__) || defined(__ppc64__)
+// https://www.cocoawithlove.com/2008/03/break-into-debugger.html
+#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("li r0, 20\nsc\nnop\nli r0, 37\nli r4, 2\nsc\nnop\n": : : "memory","r0","r3","r4") // NOLINT(hicpp-no-assembler)
+#else
+#define DOCTEST_BREAK_INTO_DEBUGGER() __asm__("brk #0"); // NOLINT(hicpp-no-assembler)
+#endif
 #elif DOCTEST_MSVC
 #define DOCTEST_BREAK_INTO_DEBUGGER() __debugbreak()
 #elif defined(__MINGW32__)
@@ -367,59 +457,72 @@ extern "C" __declspec(dllimport) void __stdcall DebugBreak();
 DOCTEST_GCC_SUPPRESS_WARNING_POP
 #define DOCTEST_BREAK_INTO_DEBUGGER() ::DebugBreak()
 #else // linux
-#define DOCTEST_BREAK_INTO_DEBUGGER() ((void)0)
+#define DOCTEST_BREAK_INTO_DEBUGGER() (static_cast<void>(0))
 #endif // linux
+#endif // DOCTEST_BREAK_INTO_DEBUGGER
 
 // this is kept here for backwards compatibility since the config option was changed
 #ifdef DOCTEST_CONFIG_USE_IOSFWD
+#ifndef DOCTEST_CONFIG_USE_STD_HEADERS
 #define DOCTEST_CONFIG_USE_STD_HEADERS
+#endif
 #endif // DOCTEST_CONFIG_USE_IOSFWD
 
-#ifdef DOCTEST_CONFIG_USE_STD_HEADERS
-#include <iosfwd>
-#include <cstddef>
-#if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
-// see this issue on why this is needed: https://github.com/onqtam/doctest/issues/183
-#include <ostream>
-#endif // VS 2019
-#else // DOCTEST_CONFIG_USE_STD_HEADERS
-
+// for clang - always include ciso646 (which drags some std stuff) because
+// we want to check if we are using libc++ with the _LIBCPP_VERSION macro in
+// which case we don't want to forward declare stuff from std - for reference:
+// https://github.com/doctest/doctest/issues/126
+// https://github.com/doctest/doctest/issues/356
 #if DOCTEST_CLANG
-// to detect if libc++ is being used with clang (the _LIBCPP_VERSION identifier)
 #include <ciso646>
+#ifdef _LIBCPP_VERSION
+#ifndef DOCTEST_CONFIG_USE_STD_HEADERS
+#define DOCTEST_CONFIG_USE_STD_HEADERS
+#endif
+#endif // _LIBCPP_VERSION
 #endif // clang
 
-#ifdef _LIBCPP_VERSION
-#define DOCTEST_STD_NAMESPACE_BEGIN _LIBCPP_BEGIN_NAMESPACE_STD
-#define DOCTEST_STD_NAMESPACE_END _LIBCPP_END_NAMESPACE_STD
-#else // _LIBCPP_VERSION
-#define DOCTEST_STD_NAMESPACE_BEGIN namespace std {
-#define DOCTEST_STD_NAMESPACE_END }
-#endif // _LIBCPP_VERSION
+#ifdef DOCTEST_CONFIG_USE_STD_HEADERS
+#ifndef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#define DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+#endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
+#include <cstddef>
+#include <ostream>
+#include <istream>
+DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
+#else // DOCTEST_CONFIG_USE_STD_HEADERS
 
 // Forward declaring 'X' in namespace std is not permitted by the C++ Standard.
 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4643)
 
-DOCTEST_STD_NAMESPACE_BEGIN // NOLINT (cert-dcl58-cpp)
-typedef decltype(nullptr) nullptr_t;
+namespace std { // NOLINT(cert-dcl58-cpp)
+typedef decltype(nullptr) nullptr_t; // NOLINT(modernize-use-using)
+typedef decltype(sizeof(void*)) size_t; // NOLINT(modernize-use-using)
 template <class charT>
 struct char_traits;
 template <>
 struct char_traits<char>;
 template <class charT, class traits>
-class basic_ostream;
-typedef basic_ostream<char, char_traits<char>> ostream;
+class basic_ostream; // NOLINT(fuchsia-virtual-inheritance)
+typedef basic_ostream<char, char_traits<char>> ostream; // NOLINT(modernize-use-using)
+template<class traits>
+// NOLINTNEXTLINE
+basic_ostream<char, traits>& operator<<(basic_ostream<char, traits>&, const char*);
+template <class charT, class traits>
+class basic_istream;
+typedef basic_istream<char, char_traits<char>> istream; // NOLINT(modernize-use-using)
 template <class... Types>
 class tuple;
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
-// see this issue on why this is needed: https://github.com/onqtam/doctest/issues/183
-template <class _Ty>
+// see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
+template <class Ty>
 class allocator;
-template <class _Elem, class _Traits, class _Alloc>
+template <class Elem, class Traits, class Alloc>
 class basic_string;
 using string = basic_string<char, char_traits<char>, allocator<char>>;
 #endif // VS 2019
-DOCTEST_STD_NAMESPACE_END
+} // namespace std
 
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
@@ -431,7 +534,13 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
 namespace doctest {
 
+using std::size_t;
+
 DOCTEST_INTERFACE extern bool is_running_in_test;
+
+#ifndef DOCTEST_CONFIG_STRING_SIZE_TYPE
+#define DOCTEST_CONFIG_STRING_SIZE_TYPE unsigned
+#endif
 
 // A 24 byte string class (can be as small as 17 for x64 and 13 for x86) that can hold strings with length
 // of up to 23 chars on the stack before going on the heap - the last byte of the buffer is used for:
@@ -445,7 +554,6 @@ DOCTEST_INTERFACE extern bool is_running_in_test;
 // TODO:
 // - optimizations - like not deleting memory unnecessarily in operator= and etc.
 // - resize/reserve/clear
-// - substr
 // - replace
 // - back/front
 // - iterator stuff
@@ -455,62 +563,83 @@ DOCTEST_INTERFACE extern bool is_running_in_test;
 // - relational operators as free functions - taking const char* as one of the params
 class DOCTEST_INTERFACE String
 {
-    static const unsigned len  = 24;      //!OCLINT avoid private static members
-    static const unsigned last = len - 1; //!OCLINT avoid private static members
+public:
+    using size_type = DOCTEST_CONFIG_STRING_SIZE_TYPE;
+
+private:
+    static DOCTEST_CONSTEXPR size_type len  = 24;      //!OCLINT avoid private static members
+    static DOCTEST_CONSTEXPR size_type last = len - 1; //!OCLINT avoid private static members
 
     struct view // len should be more than sizeof(view) - because of the final byte for flags
     {
         char*    ptr;
-        unsigned size;
-        unsigned capacity;
+        size_type size;
+        size_type capacity;
     };
 
     union
     {
-        char buf[len];
+        char buf[len]; // NOLINT(*-avoid-c-arrays)
         view data;
     };
 
-    bool isOnStack() const { return (buf[last] & 128) == 0; }
-    void setOnHeap();
-    void setLast(unsigned in = last);
+    char* allocate(size_type sz);
+
+    bool isOnStack() const noexcept { return (buf[last] & 128) == 0; }
+    void setOnHeap() noexcept;
+    void setLast(size_type in = last) noexcept;
+    void setSize(size_type sz) noexcept;
 
     void copy(const String& other);
 
 public:
-    String();
+    static DOCTEST_CONSTEXPR size_type npos = static_cast<size_type>(-1);
+
+    String() noexcept;
     ~String();
 
     // cppcheck-suppress noExplicitConstructor
     String(const char* in);
-    String(const char* in, unsigned in_size);
+    String(const char* in, size_type in_size);
+
+    String(std::istream& in, size_type in_size);
 
     String(const String& other);
     String& operator=(const String& other);
 
     String& operator+=(const String& other);
-    String  operator+(const String& other) const;
 
-    String(String&& other);
-    String& operator=(String&& other);
+    String(String&& other) noexcept;
+    String& operator=(String&& other) noexcept;
 
-    char  operator[](unsigned i) const;
-    char& operator[](unsigned i);
+    char  operator[](size_type i) const;
+    char& operator[](size_type i);
 
     // the only functions I'm willing to leave in the interface - available for inlining
     const char* c_str() const { return const_cast<String*>(this)->c_str(); } // NOLINT
     char*       c_str() {
-        if(isOnStack())
+        if (isOnStack()) {
             return reinterpret_cast<char*>(buf);
+        }
         return data.ptr;
     }
 
-    unsigned size() const;
-    unsigned capacity() const;
+    size_type size() const;
+    size_type capacity() const;
+
+    String substr(size_type pos, size_type cnt = npos) &&;
+    String substr(size_type pos, size_type cnt = npos) const &;
+
+    size_type find(char ch, size_type pos = 0) const;
+    size_type rfind(char ch, size_type pos = npos) const;
 
     int compare(const char* other, bool no_case = false) const;
     int compare(const String& other, bool no_case = false) const;
+
+friend DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, const String& in);
 };
+
+DOCTEST_INTERFACE String operator+(const String& lhs, const String& rhs);
 
 DOCTEST_INTERFACE bool operator==(const String& lhs, const String& rhs);
 DOCTEST_INTERFACE bool operator!=(const String& lhs, const String& rhs);
@@ -519,7 +648,21 @@ DOCTEST_INTERFACE bool operator>(const String& lhs, const String& rhs);
 DOCTEST_INTERFACE bool operator<=(const String& lhs, const String& rhs);
 DOCTEST_INTERFACE bool operator>=(const String& lhs, const String& rhs);
 
-DOCTEST_INTERFACE std::ostream& operator<<(std::ostream& s, const String& in);
+class DOCTEST_INTERFACE Contains {
+public:
+    explicit Contains(const String& string);
+
+    bool checkWith(const String& other) const;
+
+    String string;
+};
+
+DOCTEST_INTERFACE String toString(const Contains& in);
+
+DOCTEST_INTERFACE bool operator==(const String& lhs, const Contains& rhs);
+DOCTEST_INTERFACE bool operator==(const Contains& lhs, const String& rhs);
+DOCTEST_INTERFACE bool operator!=(const String& lhs, const Contains& rhs);
+DOCTEST_INTERFACE bool operator!=(const Contains& lhs, const String& rhs);
 
 namespace Color {
     enum Enum
@@ -593,6 +736,10 @@ namespace assertType {
         DT_CHECK_THROWS_WITH   = is_throws_with | is_check,
         DT_REQUIRE_THROWS_WITH = is_throws_with | is_require,
 
+        DT_WARN_THROWS_WITH_AS    = is_throws_with | is_throws_as | is_warn,
+        DT_CHECK_THROWS_WITH_AS   = is_throws_with | is_throws_as | is_check,
+        DT_REQUIRE_THROWS_WITH_AS = is_throws_with | is_throws_as | is_require,
+
         DT_WARN_NOTHROW    = is_nothrow | is_warn,
         DT_CHECK_NOTHROW   = is_nothrow | is_check,
         DT_REQUIRE_NOTHROW = is_nothrow | is_require,
@@ -637,19 +784,18 @@ DOCTEST_INTERFACE const char* skipPathFromFilename(const char* file);
 
 struct DOCTEST_INTERFACE TestCaseData
 {
-    const char* m_file;       // the file in which the test was registered
+    String      m_file;       // the file in which the test was registered (using String - see #350)
     unsigned    m_line;       // the line where the test was registered
     const char* m_name;       // name of the test case
     const char* m_test_suite; // the test suite in which the test was added
     const char* m_description;
     bool        m_skip;
+    bool        m_no_breaks;
+    bool        m_no_output;
     bool        m_may_fail;
     bool        m_should_fail;
     int         m_expected_failures;
     double      m_timeout;
-
-    DOCTEST_DECLARE_DEFAULTS(TestCaseData);
-    DOCTEST_DECLARE_COPIES(TestCaseData);
 };
 
 struct DOCTEST_INTERFACE AssertData
@@ -670,11 +816,27 @@ struct DOCTEST_INTERFACE AssertData
     String m_decomp;
 
     // for specific exception-related asserts
-    bool        m_threw_as;
-    const char* m_exception_type;
+    bool           m_threw_as;
+    const char*    m_exception_type;
 
-    DOCTEST_DECLARE_DEFAULTS(AssertData);
-    DOCTEST_DELETE_COPIES(AssertData);
+    class DOCTEST_INTERFACE StringContains {
+        private:
+            Contains content;
+            bool isContains;
+
+        public:
+            StringContains(const String& str) : content(str), isContains(false) { }
+            StringContains(Contains cntn) : content(static_cast<Contains&&>(cntn)), isContains(true) { }
+
+            bool check(const String& str) { return isContains ? (content == str) : (content.string == str); }
+
+            operator const String&() const { return content.string; }
+
+            const char* c_str() const { return content.string.c_str(); }
+    } m_exception_string;
+
+    AssertData(assertType::Enum at, const char* file, int line, const char* expr,
+        const char* exception_type, const StringContains& exception_string);
 };
 
 struct DOCTEST_INTERFACE MessageData
@@ -683,39 +845,34 @@ struct DOCTEST_INTERFACE MessageData
     const char*      m_file;
     int              m_line;
     assertType::Enum m_severity;
-
-    DOCTEST_DECLARE_DEFAULTS(MessageData);
-    DOCTEST_DELETE_COPIES(MessageData);
 };
 
 struct DOCTEST_INTERFACE SubcaseSignature
 {
-    const char* m_name;
+    String      m_name;
     const char* m_file;
     int         m_line;
 
-    SubcaseSignature(const char* name, const char* file, int line);
-
+    bool operator==(const SubcaseSignature& other) const;
     bool operator<(const SubcaseSignature& other) const;
-
-    DOCTEST_DECLARE_DEFAULTS(SubcaseSignature);
-    DOCTEST_DECLARE_COPIES(SubcaseSignature);
 };
 
 struct DOCTEST_INTERFACE IContextScope
 {
-    DOCTEST_DELETE_COPIES(IContextScope);
-
-    IContextScope();
-    virtual ~IContextScope();
+    DOCTEST_DECLARE_INTERFACE(IContextScope)
     virtual void stringify(std::ostream*) const = 0;
 };
 
+namespace detail {
+    struct DOCTEST_INTERFACE TestCase;
+} // namespace detail
+
 struct ContextOptions //!OCLINT too many fields
 {
-    std::ostream* cout;        // stdout stream - std::cout by default
-    std::ostream* cerr;        // stderr stream - std::cerr by default
-    String        binary_name; // the test binary name
+    std::ostream* cout = nullptr; // stdout stream
+    String        binary_name;    // the test binary name
+
+    const detail::TestCase* currentTest = nullptr;
 
     // == parameters from the command line
     String   out;       // output filename
@@ -732,9 +889,12 @@ struct ContextOptions //!OCLINT too many fields
     bool case_sensitive;       // if filtering should be case sensitive
     bool exit;                 // if the program should be exited after the tests are ran/whatever
     bool duration;             // print the time duration of each test case
+    bool minimal;              // minimal console output (only test failures)
+    bool quiet;                // no console output
     bool no_throw;             // to skip exceptions-related assertion macros
     bool no_exitcode;          // if the framework should return 0 as the exitcode
     bool no_run;               // to not run the tests at all (can be done with an "*" exclude)
+    bool no_intro;             // to not print the intro of the framework
     bool no_version;           // to not print the version of the framework
     bool no_colors;            // if output to the console should be colorized
     bool force_colors;         // forces the use of colors even when a tty cannot be detected
@@ -743,145 +903,197 @@ struct ContextOptions //!OCLINT too many fields
     bool gnu_file_line;        // if line numbers should be surrounded with :x: and not (x):
     bool no_path_in_filenames; // if the path to files should be removed from the output
     bool no_line_numbers;      // if source code line numbers should be omitted from the output
+    bool no_debug_output;      // no output in the debug console when a debugger is attached
     bool no_skipped_summary;   // don't print "skipped" in the summary !!! UNDOCUMENTED !!!
+    bool no_time_in_output;    // omit any time/timestamps from output !!! UNDOCUMENTED !!!
 
     bool help;             // to print the help
     bool version;          // to print the version
-    bool count;            // if only the count of matching tests is to be retreived
+    bool count;            // if only the count of matching tests is to be retrieved
     bool list_test_cases;  // to list all tests matching the filters
     bool list_test_suites; // to list all suites matching the filters
     bool list_reporters;   // lists all registered reporters
-
-    DOCTEST_DECLARE_DEFAULTS(ContextOptions);
-    DOCTEST_DELETE_COPIES(ContextOptions);
 };
 
 namespace detail {
-#if defined(DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING) || defined(DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS)
-    template <bool CONDITION, typename TYPE = void>
-    struct enable_if
-    {};
-
-    template <typename TYPE>
-    struct enable_if<true, TYPE>
-    { typedef TYPE type; };
-#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING) || DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
-
-    // clang-format off
-    template<class T> struct remove_reference      { typedef T type; };
-    template<class T> struct remove_reference<T&>  { typedef T type; };
-    template<class T> struct remove_reference<T&&> { typedef T type; };
-
-    template<class T> struct remove_const          { typedef T type; };
-    template<class T> struct remove_const<const T> { typedef T type; };
-    // clang-format on
-
-    template <typename T>
-    struct deferred_false
-    // cppcheck-suppress unusedStructMember
-    { static const bool value = false; };
-
-    namespace has_insertion_operator_impl {
-        typedef char no;
-        typedef char yes[2];
-
-        struct any_t
-        {
-            template <typename T>
-            // cppcheck-suppress noExplicitConstructor
-            any_t(const DOCTEST_REF_WRAP(T));
-        };
-
-        yes& testStreamable(std::ostream&);
-        no   testStreamable(no);
-
-        no operator<<(const std::ostream&, const any_t&);
+    namespace types {
+#ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
+        using namespace std;
+#else
+        template <bool COND, typename T = void>
+        struct enable_if { };
 
         template <typename T>
-        struct has_insertion_operator
-        {
-            static std::ostream& s;
-            static const DOCTEST_REF_WRAP(T) t;
-            static const bool value = sizeof(decltype(testStreamable(s << t))) == sizeof(yes);
-        };
-    } // namespace has_insertion_operator_impl
+        struct enable_if<true, T> { using type = T; };
+
+        struct true_type { static DOCTEST_CONSTEXPR bool value = true; };
+        struct false_type { static DOCTEST_CONSTEXPR bool value = false; };
+
+        template <typename T> struct remove_reference { using type = T; };
+        template <typename T> struct remove_reference<T&> { using type = T; };
+        template <typename T> struct remove_reference<T&&> { using type = T; };
+
+        template <typename T> struct is_rvalue_reference : false_type { };
+        template <typename T> struct is_rvalue_reference<T&&> : true_type { };
+
+        template<typename T> struct remove_const { using type = T; };
+        template <typename T> struct remove_const<const T> { using type = T; };
+
+        // Compiler intrinsics
+        template <typename T> struct is_enum { static DOCTEST_CONSTEXPR bool value = __is_enum(T); };
+        template <typename T> struct underlying_type { using type = __underlying_type(T); };
+
+        template <typename T> struct is_pointer : false_type { };
+        template <typename T> struct is_pointer<T*> : true_type { };
+
+        template <typename T> struct is_array : false_type { };
+        // NOLINTNEXTLINE(*-avoid-c-arrays)
+        template <typename T, size_t SIZE> struct is_array<T[SIZE]> : true_type { };
+#endif
+    }
+
+    // <utility>
+    template <typename T>
+    T&& declval();
+
+    template <class T>
+    DOCTEST_CONSTEXPR_FUNC T&& forward(typename types::remove_reference<T>::type& t) DOCTEST_NOEXCEPT {
+        return static_cast<T&&>(t);
+    }
+
+    template <class T>
+    DOCTEST_CONSTEXPR_FUNC T&& forward(typename types::remove_reference<T>::type&& t) DOCTEST_NOEXCEPT {
+        return static_cast<T&&>(t);
+    }
 
     template <typename T>
-    struct has_insertion_operator : has_insertion_operator_impl::has_insertion_operator<T>
-    {};
+    struct deferred_false : types::false_type { };
 
-    DOCTEST_INTERFACE void my_memcpy(void* dest, const void* src, unsigned num);
+// MSVS 2015 :(
+#if defined(_MSC_VER) && _MSC_VER <= 1900
+    template <typename T, typename = void>
+    struct has_global_insertion_operator : types::false_type { };
 
-    DOCTEST_INTERFACE std::ostream* getTlsOss(); // returns a thread-local ostringstream
-    DOCTEST_INTERFACE String getTlsOssResult();
+    template <typename T>
+    struct has_global_insertion_operator<T, decltype(::operator<<(declval<std::ostream&>(), declval<const T&>()), void())> : types::true_type { };
+
+    template <typename T, typename = void>
+    struct has_insertion_operator { static DOCTEST_CONSTEXPR bool value = has_global_insertion_operator<T>::value; };
+
+    template <typename T, bool global>
+    struct insert_hack;
+
+    template <typename T>
+    struct insert_hack<T, true> {
+        static void insert(std::ostream& os, const T& t) { ::operator<<(os, t); }
+    };
+
+    template <typename T>
+    struct insert_hack<T, false> {
+        static void insert(std::ostream& os, const T& t) { operator<<(os, t); }
+    };
+
+    template <typename T>
+    using insert_hack_t = insert_hack<T, has_global_insertion_operator<T>::value>;
+#else
+    template <typename T, typename = void>
+    struct has_insertion_operator : types::false_type { };
+#endif
+
+template <typename T>
+struct has_insertion_operator<T, decltype(operator<<(declval<std::ostream&>(), declval<const T&>()), void())> : types::true_type { };
+
+    DOCTEST_INTERFACE std::ostream* tlssPush();
+    DOCTEST_INTERFACE String tlssPop();
 
     template <bool C>
-    struct StringMakerBase
-    {
+    struct StringMakerBase {
         template <typename T>
         static String convert(const DOCTEST_REF_WRAP(T)) {
+#ifdef DOCTEST_CONFIG_REQUIRE_STRINGIFICATION_FOR_ALL_USED_TYPES
+            static_assert(deferred_false<T>::value, "No stringification detected for type T. See string conversion manual");
+#endif
             return "{?}";
         }
     };
 
+    template <typename T>
+    struct filldata;
+
+    template <typename T>
+    void filloss(std::ostream* stream, const T& in) {
+        filldata<T>::fill(stream, in);
+    }
+
+    template <typename T, size_t N>
+    void filloss(std::ostream* stream, const T (&in)[N]) { // NOLINT(*-avoid-c-arrays)
+        // T[N], T(&)[N], T(&&)[N] have same behaviour.
+        // Hence remove reference.
+        filloss<typename types::remove_reference<decltype(in)>::type>(stream, in);
+    }
+
+    template <typename T>
+    String toStream(const T& in) {
+        std::ostream* stream = tlssPush();
+        filloss(stream, in);
+        return tlssPop();
+    }
+
     template <>
-    struct StringMakerBase<true>
-    {
+    struct StringMakerBase<true> {
         template <typename T>
         static String convert(const DOCTEST_REF_WRAP(T) in) {
-            *getTlsOss() << in;
-            return getTlsOssResult();
+            return toStream(in);
         }
     };
-
-    DOCTEST_INTERFACE String rawMemoryToString(const void* object, unsigned size);
-
-    template <typename T>
-    String rawMemoryToString(const DOCTEST_REF_WRAP(T) object) {
-        return rawMemoryToString(&object, sizeof(object));
-    }
-
-    template <typename T>
-    const char* type_to_string() {
-        return "<>";
-    }
 } // namespace detail
 
 template <typename T>
-struct StringMaker : public detail::StringMakerBase<detail::has_insertion_operator<T>::value>
+struct StringMaker : public detail::StringMakerBase<
+    detail::has_insertion_operator<T>::value || detail::types::is_pointer<T>::value || detail::types::is_array<T>::value>
 {};
 
-template <typename T>
-struct StringMaker<T*>
-{
-    template <typename U>
-    static String convert(U* p) {
-        if(p)
-            return detail::rawMemoryToString(p);
-        return "NULL";
-    }
-};
-
-template <typename R, typename C>
-struct StringMaker<R C::*>
-{
-    static String convert(R C::*p) {
-        if(p)
-            return detail::rawMemoryToString(p);
-        return "NULL";
-    }
-};
+#ifndef DOCTEST_STRINGIFY
+#ifdef DOCTEST_CONFIG_DOUBLE_STRINGIFY
+#define DOCTEST_STRINGIFY(...) toString(toString(__VA_ARGS__))
+#else
+#define DOCTEST_STRINGIFY(...) toString(__VA_ARGS__)
+#endif
+#endif
 
 template <typename T>
+String toString() {
+#if DOCTEST_MSVC >= 0 && DOCTEST_CLANG == 0 && DOCTEST_GCC == 0
+    String ret = __FUNCSIG__; // class doctest::String __cdecl doctest::toString<TYPE>(void)
+    String::size_type beginPos = ret.find('<');
+    return ret.substr(beginPos + 1, ret.size() - beginPos - static_cast<String::size_type>(sizeof(">(void)")));
+#else
+    String ret = __PRETTY_FUNCTION__; // doctest::String toString() [with T = TYPE]
+    String::size_type begin = ret.find('=') + 2;
+    return ret.substr(begin, ret.size() - begin - 1);
+#endif
+}
+
+template <typename T, typename detail::types::enable_if<!detail::types::is_enum<T>::value, bool>::type = true>
 String toString(const DOCTEST_REF_WRAP(T) value) {
     return StringMaker<T>::convert(value);
 }
 
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-DOCTEST_INTERFACE String toString(char* in);
 DOCTEST_INTERFACE String toString(const char* in);
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+
+#if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
+// see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
+DOCTEST_INTERFACE String toString(const std::string& in);
+#endif // VS 2019
+
+DOCTEST_INTERFACE String toString(String in);
+
+DOCTEST_INTERFACE String toString(std::nullptr_t);
+
 DOCTEST_INTERFACE String toString(bool in);
+
 DOCTEST_INTERFACE String toString(float in);
 DOCTEST_INTERFACE String toString(double in);
 DOCTEST_INTERFACE String toString(double long in);
@@ -889,36 +1101,85 @@ DOCTEST_INTERFACE String toString(double long in);
 DOCTEST_INTERFACE String toString(char in);
 DOCTEST_INTERFACE String toString(char signed in);
 DOCTEST_INTERFACE String toString(char unsigned in);
-DOCTEST_INTERFACE String toString(int short in);
-DOCTEST_INTERFACE String toString(int short unsigned in);
-DOCTEST_INTERFACE String toString(int in);
-DOCTEST_INTERFACE String toString(int unsigned in);
-DOCTEST_INTERFACE String toString(int long in);
-DOCTEST_INTERFACE String toString(int long unsigned in);
-DOCTEST_INTERFACE String toString(int long long in);
-DOCTEST_INTERFACE String toString(int long long unsigned in);
-DOCTEST_INTERFACE String toString(std::nullptr_t in);
+DOCTEST_INTERFACE String toString(short in);
+DOCTEST_INTERFACE String toString(short unsigned in);
+DOCTEST_INTERFACE String toString(signed in);
+DOCTEST_INTERFACE String toString(unsigned in);
+DOCTEST_INTERFACE String toString(long in);
+DOCTEST_INTERFACE String toString(long unsigned in);
+DOCTEST_INTERFACE String toString(long long in);
+DOCTEST_INTERFACE String toString(long long unsigned in);
 
-#if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
-// see this issue on why this is needed: https://github.com/onqtam/doctest/issues/183
-DOCTEST_INTERFACE String toString(const std::string& in);
-#endif // VS 2019
+template <typename T, typename detail::types::enable_if<detail::types::is_enum<T>::value, bool>::type = true>
+String toString(const DOCTEST_REF_WRAP(T) value) {
+    using UT = typename detail::types::underlying_type<T>::type;
+    return (DOCTEST_STRINGIFY(static_cast<UT>(value)));
+}
 
-class DOCTEST_INTERFACE Approx
+namespace detail {
+    template <typename T>
+    struct filldata
+    {
+        static void fill(std::ostream* stream, const T& in) {
+#if defined(_MSC_VER) && _MSC_VER <= 1900
+        insert_hack_t<T>::insert(*stream, in);
+#else
+        operator<<(*stream, in);
+#endif
+        }
+    };
+
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
+// NOLINTBEGIN(*-avoid-c-arrays)
+    template <typename T, size_t N>
+    struct filldata<T[N]> {
+        static void fill(std::ostream* stream, const T(&in)[N]) {
+            *stream << "[";
+            for (size_t i = 0; i < N; i++) {
+                if (i != 0) { *stream << ", "; }
+                *stream << (DOCTEST_STRINGIFY(in[i]));
+            }
+            *stream << "]";
+        }
+    };
+// NOLINTEND(*-avoid-c-arrays)
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+    // Specialized since we don't want the terminating null byte!
+// NOLINTBEGIN(*-avoid-c-arrays)
+    template <size_t N>
+    struct filldata<const char[N]> {
+        static void fill(std::ostream* stream, const char (&in)[N]) {
+            *stream << String(in, in[N - 1] ? N : N - 1);
+        } // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+    };
+// NOLINTEND(*-avoid-c-arrays)
+
+    template <>
+    struct filldata<const void*> {
+        static void fill(std::ostream* stream, const void* in);
+    };
+
+    template <typename T>
+    struct filldata<T*> {
+        static void fill(std::ostream* stream, const T* in) {
+            filldata<const void*>::fill(stream, in);
+        }
+    };
+}
+
+struct DOCTEST_INTERFACE Approx
 {
-public:
-    explicit Approx(double value);
-
-    DOCTEST_DECLARE_COPIES(Approx);
+    Approx(double value);
 
     Approx operator()(double value) const;
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
     template <typename T>
     explicit Approx(const T& value,
-                    typename detail::enable_if<std::is_constructible<double, T>::value>::type* =
+                    typename detail::types::enable_if<std::is_constructible<double, T>::value>::type* =
                             static_cast<T*>(nullptr)) {
-        *this = Approx(static_cast<double>(value));
+        *this = static_cast<double>(value);
     }
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
@@ -926,7 +1187,7 @@ public:
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
     template <typename T>
-    typename detail::enable_if<std::is_constructible<double, T>::value, Approx&>::type epsilon(
+    typename std::enable_if<std::is_constructible<double, T>::value, Approx&>::type epsilon(
             const T& newEpsilon) {
         m_epsilon = static_cast<double>(newEpsilon);
         return *this;
@@ -937,7 +1198,7 @@ public:
 
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
     template <typename T>
-    typename detail::enable_if<std::is_constructible<double, T>::value, Approx&>::type scale(
+    typename std::enable_if<std::is_constructible<double, T>::value, Approx&>::type scale(
             const T& newScale) {
         m_scale = static_cast<double>(newScale);
         return *this;
@@ -958,30 +1219,27 @@ public:
     DOCTEST_INTERFACE friend bool operator> (double lhs, const Approx & rhs);
     DOCTEST_INTERFACE friend bool operator> (const Approx & lhs, double rhs);
 
-    DOCTEST_INTERFACE friend String toString(const Approx& in);
-
 #ifdef DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 #define DOCTEST_APPROX_PREFIX \
-    template <typename T> friend typename detail::enable_if<std::is_constructible<double, T>::value, bool>::type
+    template <typename T> friend typename std::enable_if<std::is_constructible<double, T>::value, bool>::type
 
-    DOCTEST_APPROX_PREFIX operator==(const T& lhs, const Approx& rhs) { return operator==(double(lhs), rhs); }
+    DOCTEST_APPROX_PREFIX operator==(const T& lhs, const Approx& rhs) { return operator==(static_cast<double>(lhs), rhs); }
     DOCTEST_APPROX_PREFIX operator==(const Approx& lhs, const T& rhs) { return operator==(rhs, lhs); }
     DOCTEST_APPROX_PREFIX operator!=(const T& lhs, const Approx& rhs) { return !operator==(lhs, rhs); }
     DOCTEST_APPROX_PREFIX operator!=(const Approx& lhs, const T& rhs) { return !operator==(rhs, lhs); }
-    DOCTEST_APPROX_PREFIX operator<=(const T& lhs, const Approx& rhs) { return double(lhs) < rhs.m_value || lhs == rhs; }
-    DOCTEST_APPROX_PREFIX operator<=(const Approx& lhs, const T& rhs) { return lhs.m_value < double(rhs) || lhs == rhs; }
-    DOCTEST_APPROX_PREFIX operator>=(const T& lhs, const Approx& rhs) { return double(lhs) > rhs.m_value || lhs == rhs; }
-    DOCTEST_APPROX_PREFIX operator>=(const Approx& lhs, const T& rhs) { return lhs.m_value > double(rhs) || lhs == rhs; }
-    DOCTEST_APPROX_PREFIX operator< (const T& lhs, const Approx& rhs) { return double(lhs) < rhs.m_value && lhs != rhs; }
-    DOCTEST_APPROX_PREFIX operator< (const Approx& lhs, const T& rhs) { return lhs.m_value < double(rhs) && lhs != rhs; }
-    DOCTEST_APPROX_PREFIX operator> (const T& lhs, const Approx& rhs) { return double(lhs) > rhs.m_value && lhs != rhs; }
-    DOCTEST_APPROX_PREFIX operator> (const Approx& lhs, const T& rhs) { return lhs.m_value > double(rhs) && lhs != rhs; }
+    DOCTEST_APPROX_PREFIX operator<=(const T& lhs, const Approx& rhs) { return static_cast<double>(lhs) < rhs.m_value || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator<=(const Approx& lhs, const T& rhs) { return lhs.m_value < static_cast<double>(rhs) || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator>=(const T& lhs, const Approx& rhs) { return static_cast<double>(lhs) > rhs.m_value || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator>=(const Approx& lhs, const T& rhs) { return lhs.m_value > static_cast<double>(rhs) || lhs == rhs; }
+    DOCTEST_APPROX_PREFIX operator< (const T& lhs, const Approx& rhs) { return static_cast<double>(lhs) < rhs.m_value && lhs != rhs; }
+    DOCTEST_APPROX_PREFIX operator< (const Approx& lhs, const T& rhs) { return lhs.m_value < static_cast<double>(rhs) && lhs != rhs; }
+    DOCTEST_APPROX_PREFIX operator> (const T& lhs, const Approx& rhs) { return static_cast<double>(lhs) > rhs.m_value && lhs != rhs; }
+    DOCTEST_APPROX_PREFIX operator> (const Approx& lhs, const T& rhs) { return lhs.m_value > static_cast<double>(rhs) && lhs != rhs; }
 #undef DOCTEST_APPROX_PREFIX
 #endif // DOCTEST_CONFIG_INCLUDE_TYPE_TRAITS
 
     // clang-format on
 
-private:
     double m_epsilon;
     double m_scale;
     double m_value;
@@ -991,18 +1249,35 @@ DOCTEST_INTERFACE String toString(const Approx& in);
 
 DOCTEST_INTERFACE const ContextOptions* getContextOptions();
 
-#if !defined(DOCTEST_CONFIG_DISABLE)
+template <typename F>
+struct DOCTEST_INTERFACE_DECL IsNaN
+{
+    F value; bool flipped;
+    IsNaN(F f, bool flip = false) : value(f), flipped(flip) { }
+    IsNaN<F> operator!() const { return { value, !flipped }; }
+    operator bool() const;
+};
+#ifndef __MINGW32__
+extern template struct DOCTEST_INTERFACE_DECL IsNaN<float>;
+extern template struct DOCTEST_INTERFACE_DECL IsNaN<double>;
+extern template struct DOCTEST_INTERFACE_DECL IsNaN<long double>;
+#endif
+DOCTEST_INTERFACE String toString(IsNaN<float> in);
+DOCTEST_INTERFACE String toString(IsNaN<double> in);
+DOCTEST_INTERFACE String toString(IsNaN<double long> in);
+
+#ifndef DOCTEST_CONFIG_DISABLE
 
 namespace detail {
     // clang-format off
 #ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    template<class T>               struct decay_array       { typedef T type; };
-    template<class T, unsigned N>   struct decay_array<T[N]> { typedef T* type; };
-    template<class T>               struct decay_array<T[]>  { typedef T* type; };
+    template<class T>               struct decay_array       { using type = T; };
+    template<class T, unsigned N>   struct decay_array<T[N]> { using type = T*; };
+    template<class T>               struct decay_array<T[]>  { using type = T*; };
 
-    template<class T>   struct not_char_pointer              { enum { value = 1 }; };
-    template<>          struct not_char_pointer<char*>       { enum { value = 0 }; };
-    template<>          struct not_char_pointer<const char*> { enum { value = 0 }; };
+    template<class T>   struct not_char_pointer              { static DOCTEST_CONSTEXPR value = 1; };
+    template<>          struct not_char_pointer<char*>       { static DOCTEST_CONSTEXPR value = 0; };
+    template<>          struct not_char_pointer<const char*> { static DOCTEST_CONSTEXPR value = 0; };
 
     template<class T> struct can_use_op : public not_char_pointer<typename decay_array<T>::type> {};
 #endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
@@ -1010,14 +1285,12 @@ namespace detail {
 
     struct DOCTEST_INTERFACE TestFailureException
     {
-        DOCTEST_DECLARE_DEFAULTS(TestFailureException);
-        DOCTEST_DECLARE_COPIES(TestFailureException);
     };
 
     DOCTEST_INTERFACE bool checkIfShouldThrow(assertType::Enum at);
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-    [[noreturn]]
+    DOCTEST_NORETURN
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
     DOCTEST_INTERFACE void throwException();
 
@@ -1026,24 +1299,39 @@ namespace detail {
         SubcaseSignature m_signature;
         bool             m_entered = false;
 
-        Subcase(const char* name, const char* file, int line);
+        Subcase(const String& name, const char* file, int line);
+        Subcase(const Subcase&) = delete;
+        Subcase(Subcase&&) = delete;
+        Subcase& operator=(const Subcase&) = delete;
+        Subcase& operator=(Subcase&&) = delete;
         ~Subcase();
 
-        DOCTEST_DELETE_COPIES(Subcase);
-
         operator bool() const;
+
+        private:
+            bool checkFilters();
     };
 
     template <typename L, typename R>
     String stringifyBinaryExpr(const DOCTEST_REF_WRAP(L) lhs, const char* op,
                                const DOCTEST_REF_WRAP(R) rhs) {
-        return toString(lhs) + op + toString(rhs);
+        return (DOCTEST_STRINGIFY(lhs)) + op + (DOCTEST_STRINGIFY(rhs));
     }
+
+#if DOCTEST_CLANG && DOCTEST_CLANG < DOCTEST_COMPILER(3, 6, 0)
+DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-comparison")
+#endif
+
+// This will check if there is any way it could find a operator like member or friend and uses it.
+// If not it doesn't find the operator or if the operator at global scope is defined after
+// this template, the template won't be instantiated due to SFINAE. Once the template is not
+// instantiated it can look for global operator using normal conversions.
+#define SFINAE_OP(ret,op) decltype((void)(doctest::detail::declval<L>() op doctest::detail::declval<R>()),ret{})
 
 #define DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(op, op_str, op_macro)                              \
     template <typename R>                                                                          \
-    DOCTEST_NOINLINE Result operator op(const DOCTEST_REF_WRAP(R) rhs) {                           \
-        bool res = op_macro(lhs, rhs);                                                             \
+    DOCTEST_NOINLINE SFINAE_OP(Result,op) operator op(R&& rhs) {                                   \
+    bool res = op_macro(doctest::detail::forward<const L>(lhs), doctest::detail::forward<R>(rhs)); \
         if(m_at & assertType::is_false)                                                            \
             res = !res;                                                                            \
         if(!res || doctest::getContextOptions()->success)                                          \
@@ -1062,17 +1350,15 @@ namespace detail {
         return *this;                                                                              \
     }
 
-    struct DOCTEST_INTERFACE Result
+    struct DOCTEST_INTERFACE Result // NOLINT(*-member-init)
     {
         bool   m_passed;
         String m_decomp;
 
+        Result() = default; // TODO: Why do we need this? (To remove NOLINT)
         Result(bool passed, const String& decomposition = String());
 
-        DOCTEST_DECLARE_DEFAULTS(Result);
-        DOCTEST_DECLARE_COPIES(Result);
-
-        // forbidding some expressions based on this table: http://en.cppreference.com/w/cpp/language/operator_precedence
+        // forbidding some expressions based on this table: https://en.cppreference.com/w/cpp/language/operator_precedence
         DOCTEST_FORBIT_EXPRESSION(Result, &)
         DOCTEST_FORBIT_EXPRESSION(Result, ^)
         DOCTEST_FORBIT_EXPRESSION(Result, |)
@@ -1114,7 +1400,7 @@ namespace detail {
     //DOCTEST_GCC_SUPPRESS_WARNING("-Wfloat-equal")
 
     DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-    // http://stackoverflow.com/questions/39479163 what's the difference between 4018 and 4389
+    // https://stackoverflow.com/questions/39479163 what's the difference between 4018 and 4389
     DOCTEST_MSVC_SUPPRESS_WARNING(4388) // signed/unsigned mismatch
     DOCTEST_MSVC_SUPPRESS_WARNING(4389) // 'operator' : signed/unsigned mismatch
     DOCTEST_MSVC_SUPPRESS_WARNING(4018) // 'expression' : signed/unsigned mismatch
@@ -1126,7 +1412,7 @@ namespace detail {
 #ifndef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 #define DOCTEST_COMPARISON_RETURN_TYPE bool
 #else // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-#define DOCTEST_COMPARISON_RETURN_TYPE typename enable_if<can_use_op<L>::value || can_use_op<R>::value, bool>::type
+#define DOCTEST_COMPARISON_RETURN_TYPE typename types::enable_if<can_use_op<L>::value || can_use_op<R>::value, bool>::type
     inline bool eq(const char* lhs, const char* rhs) { return String(lhs) == String(rhs); }
     inline bool ne(const char* lhs, const char* rhs) { return String(lhs) != String(rhs); }
     inline bool lt(const char* lhs, const char* rhs) { return String(lhs) <  String(rhs); }
@@ -1173,19 +1459,27 @@ namespace detail {
         L                lhs;
         assertType::Enum m_at;
 
-        explicit Expression_lhs(L in, assertType::Enum at)
-                : lhs(in)
+        explicit Expression_lhs(L&& in, assertType::Enum at)
+                : lhs(static_cast<L&&>(in))
                 , m_at(at) {}
 
         DOCTEST_NOINLINE operator Result() {
-            bool res = !!lhs;
-            if(m_at & assertType::is_false) //!OCLINT bitwise operator in conditional
+// this is needed only for MSVC 2015
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4800) // 'int': forcing value to bool
+            bool res = static_cast<bool>(lhs);
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+            if(m_at & assertType::is_false) { //!OCLINT bitwise operator in conditional
                 res = !res;
+            }
 
-            if(!res || getContextOptions()->success)
-                return Result(res, toString(lhs));
-            return Result(res);
+            if(!res || getContextOptions()->success) {
+                return { res, (DOCTEST_STRINGIFY(lhs)) };
+            }
+            return { res };
         }
+
+        /* This is required for user-defined conversions from Expression_lhs to L */
+        operator L() const { return lhs; }
 
         // clang-format off
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(==, " == ", DOCTEST_CMP_EQ) //!OCLINT bitwise operator in conditional
@@ -1196,7 +1490,7 @@ namespace detail {
         DOCTEST_DO_BINARY_EXPRESSION_COMPARISON(<=, " <= ", DOCTEST_CMP_LE) //!OCLINT bitwise operator in conditional
         // clang-format on
 
-        // forbidding some expressions based on this table: http://en.cppreference.com/w/cpp/language/operator_precedence
+        // forbidding some expressions based on this table: https://en.cppreference.com/w/cpp/language/operator_precedence
         DOCTEST_FORBIT_EXPRESSION(Expression_lhs, &)
         DOCTEST_FORBIT_EXPRESSION(Expression_lhs, ^)
         DOCTEST_FORBIT_EXPRESSION(Expression_lhs, |)
@@ -1227,37 +1521,42 @@ namespace detail {
 
 #endif // DOCTEST_CONFIG_NO_COMPARISON_WARNING_SUPPRESSION
 
+#if DOCTEST_CLANG && DOCTEST_CLANG < DOCTEST_COMPILER(3, 6, 0)
+DOCTEST_CLANG_SUPPRESS_WARNING_POP
+#endif
+
     struct DOCTEST_INTERFACE ExpressionDecomposer
     {
         assertType::Enum m_at;
 
         ExpressionDecomposer(assertType::Enum at);
 
-        DOCTEST_DECLARE_DEFAULTS(ExpressionDecomposer);
-        DOCTEST_DELETE_COPIES(ExpressionDecomposer);
-
         // The right operator for capturing expressions is "<=" instead of "<<" (based on the operator precedence table)
         // but then there will be warnings from GCC about "-Wparentheses" and since "_Pragma()" is problematic this will stay for now...
         // https://github.com/catchorg/Catch2/issues/870
         // https://github.com/catchorg/Catch2/issues/565
         template <typename L>
-        Expression_lhs<const DOCTEST_REF_WRAP(L)> operator<<(const DOCTEST_REF_WRAP(L) operand) {
-            return Expression_lhs<const DOCTEST_REF_WRAP(L)>(operand, m_at);
+        Expression_lhs<L> operator<<(L&& operand) {
+            return Expression_lhs<L>(static_cast<L&&>(operand), m_at);
+        }
+
+        template <typename L,typename types::enable_if<!doctest::detail::types::is_rvalue_reference<L>::value,void >::type* = nullptr>
+        Expression_lhs<const L&> operator<<(const L &operand) {
+            return Expression_lhs<const L&>(operand, m_at);
         }
     };
 
     struct DOCTEST_INTERFACE TestSuite
     {
-        const char* m_test_suite;
-        const char* m_description;
-        bool        m_skip;
-        bool        m_may_fail;
-        bool        m_should_fail;
-        int         m_expected_failures;
-        double      m_timeout;
-
-        DOCTEST_DECLARE_DEFAULTS(TestSuite);
-        DOCTEST_DECLARE_COPIES(TestSuite);
+        const char* m_test_suite = nullptr;
+        const char* m_description = nullptr;
+        bool        m_skip = false;
+        bool        m_no_breaks = false;
+        bool        m_no_output = false;
+        bool        m_may_fail = false;
+        bool        m_should_fail = false;
+        int         m_expected_failures = 0;
+        double      m_timeout = 0;
 
         TestSuite& operator*(const char* in);
 
@@ -1268,26 +1567,27 @@ namespace detail {
         }
     };
 
-    typedef void (*funcType)();
+    using funcType = void (*)();
 
     struct DOCTEST_INTERFACE TestCase : public TestCaseData
     {
         funcType m_test; // a function pointer to the test case
 
-        const char* m_type; // for templated test cases - gets appended to the real name
+        String m_type; // for templated test cases - gets appended to the real name
         int m_template_id; // an ID used to distinguish between the different versions of a templated test case
         String m_full_name; // contains the name (only for templated test cases!) + the template type
 
         TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
-                 const char* type = "", int template_id = -1);
-
-        DOCTEST_DECLARE_DEFAULTS(TestCase);
+                 const String& type = String(), int template_id = -1);
 
         TestCase(const TestCase& other);
+        TestCase(TestCase&&) = delete;
 
         DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434) // hides a non-virtual function
         TestCase& operator=(const TestCase& other);
         DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+        TestCase& operator=(TestCase&&) = delete;
 
         TestCase& operator*(const char* in);
 
@@ -1298,6 +1598,8 @@ namespace detail {
         }
 
         bool operator<(const TestCase& other) const;
+
+        ~TestCase() = default;
     };
 
     // forward declarations of functions used by the macros
@@ -1327,40 +1629,46 @@ namespace detail {
     template <class L, class R> struct RelationalComparator<n, L, R> { bool operator()(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) const { return op(lhs, rhs); } };
     // clang-format on
 
-    DOCTEST_BINARY_RELATIONAL_OP(0, eq)
-    DOCTEST_BINARY_RELATIONAL_OP(1, ne)
-    DOCTEST_BINARY_RELATIONAL_OP(2, gt)
-    DOCTEST_BINARY_RELATIONAL_OP(3, lt)
-    DOCTEST_BINARY_RELATIONAL_OP(4, ge)
-    DOCTEST_BINARY_RELATIONAL_OP(5, le)
+    DOCTEST_BINARY_RELATIONAL_OP(0, doctest::detail::eq)
+    DOCTEST_BINARY_RELATIONAL_OP(1, doctest::detail::ne)
+    DOCTEST_BINARY_RELATIONAL_OP(2, doctest::detail::gt)
+    DOCTEST_BINARY_RELATIONAL_OP(3, doctest::detail::lt)
+    DOCTEST_BINARY_RELATIONAL_OP(4, doctest::detail::ge)
+    DOCTEST_BINARY_RELATIONAL_OP(5, doctest::detail::le)
 
     struct DOCTEST_INTERFACE ResultBuilder : public AssertData
     {
         ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
-                      const char* exception_type = "");
+                      const char* exception_type = "", const String& exception_string = "");
 
-        DOCTEST_DECLARE_DEFAULTS(ResultBuilder);
-        DOCTEST_DELETE_COPIES(ResultBuilder);
+        ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
+                      const char* exception_type, const Contains& exception_string);
 
         void setResult(const Result& res);
 
         template <int comparison, typename L, typename R>
-        DOCTEST_NOINLINE void binary_assert(const DOCTEST_REF_WRAP(L) lhs,
+        DOCTEST_NOINLINE bool binary_assert(const DOCTEST_REF_WRAP(L) lhs,
                                             const DOCTEST_REF_WRAP(R) rhs) {
             m_failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
-            if(m_failed || getContextOptions()->success)
+            if (m_failed || getContextOptions()->success) {
                 m_decomp = stringifyBinaryExpr(lhs, ", ", rhs);
+            }
+            return !m_failed;
         }
 
         template <typename L>
-        DOCTEST_NOINLINE void unary_assert(const DOCTEST_REF_WRAP(L) val) {
+        DOCTEST_NOINLINE bool unary_assert(const DOCTEST_REF_WRAP(L) val) {
             m_failed = !val;
 
-            if(m_at & assertType::is_false) //!OCLINT bitwise operator in conditional
+            if (m_at & assertType::is_false) { //!OCLINT bitwise operator in conditional
                 m_failed = !m_failed;
+            }
 
-            if(m_failed || getContextOptions()->success)
-                m_decomp = toString(val);
+            if (m_failed || getContextOptions()->success) {
+                m_decomp = (DOCTEST_STRINGIFY(val));
+            }
+
+            return !m_failed;
         }
 
         void translateException();
@@ -1380,8 +1688,8 @@ namespace detail {
 
     DOCTEST_INTERFACE void failed_out_of_a_testing_context(const AssertData& ad);
 
-    DOCTEST_INTERFACE void decomp_assert(assertType::Enum at, const char* file, int line,
-                                         const char* expr, Result result);
+    DOCTEST_INTERFACE bool decomp_assert(assertType::Enum at, const char* file, int line,
+                                         const char* expr, const Result& result);
 
 #define DOCTEST_ASSERT_OUT_OF_TESTS(decomp)                                                        \
     do {                                                                                           \
@@ -1396,7 +1704,7 @@ namespace detail {
                 if(checkIfShouldThrow(at))                                                         \
                     throwException();                                                              \
             }                                                                                      \
-            return;                                                                                \
+            return !failed;                                                                        \
         }                                                                                          \
     } while(false)
 
@@ -1411,7 +1719,7 @@ namespace detail {
     throwException()
 
     template <int comparison, typename L, typename R>
-    DOCTEST_NOINLINE void binary_assert(assertType::Enum at, const char* file, int line,
+    DOCTEST_NOINLINE bool binary_assert(assertType::Enum at, const char* file, int line,
                                         const char* expr, const DOCTEST_REF_WRAP(L) lhs,
                                         const DOCTEST_REF_WRAP(R) rhs) {
         bool failed = !RelationalComparator<comparison, L, R>()(lhs, rhs);
@@ -1422,10 +1730,11 @@ namespace detail {
         // ###################################################################################
         DOCTEST_ASSERT_OUT_OF_TESTS(stringifyBinaryExpr(lhs, ", ", rhs));
         DOCTEST_ASSERT_IN_TESTS(stringifyBinaryExpr(lhs, ", ", rhs));
+        return !failed;
     }
 
     template <typename L>
-    DOCTEST_NOINLINE void unary_assert(assertType::Enum at, const char* file, int line,
+    DOCTEST_NOINLINE bool unary_assert(assertType::Enum at, const char* file, int line,
                                        const char* expr, const DOCTEST_REF_WRAP(L) val) {
         bool failed = !val;
 
@@ -1436,16 +1745,14 @@ namespace detail {
         // IF THE DEBUGGER BREAKS HERE - GO 1 LEVEL UP IN THE CALLSTACK FOR THE FAILING ASSERT
         // THIS IS THE EFFECT OF HAVING 'DOCTEST_CONFIG_SUPER_FAST_ASSERTS' DEFINED
         // ###################################################################################
-        DOCTEST_ASSERT_OUT_OF_TESTS(toString(val));
-        DOCTEST_ASSERT_IN_TESTS(toString(val));
+        DOCTEST_ASSERT_OUT_OF_TESTS((DOCTEST_STRINGIFY(val)));
+        DOCTEST_ASSERT_IN_TESTS((DOCTEST_STRINGIFY(val)));
+        return !failed;
     }
 
     struct DOCTEST_INTERFACE IExceptionTranslator
     {
-        DOCTEST_DELETE_COPIES(IExceptionTranslator);
-
-        IExceptionTranslator();
-        virtual ~IExceptionTranslator();
+        DOCTEST_DECLARE_INTERFACE(IExceptionTranslator)
         virtual bool translate(String&) const = 0;
     };
 
@@ -1461,12 +1768,12 @@ namespace detail {
             try {
                 throw; // lgtm [cpp/rethrow-no-exception]
                 // cppcheck-suppress catchExceptionByValue
-            } catch(T ex) {                    // NOLINT
+            } catch(const T& ex) {
                 res = m_translateFunction(ex); //!OCLINT parameter reassignment
                 return true;
-            } catch(...) {} //!OCLINT -  empty catch statement
-#endif                      // DOCTEST_CONFIG_NO_EXCEPTIONS
-            ((void)res);    // to silence -Wunused-parameter
+            } catch(...) {}         //!OCLINT -  empty catch statement
+#endif                              // DOCTEST_CONFIG_NO_EXCEPTIONS
+            static_cast<void>(res); // to silence -Wunused-parameter
             return false;
         }
 
@@ -1476,101 +1783,86 @@ namespace detail {
 
     DOCTEST_INTERFACE void registerExceptionTranslatorImpl(const IExceptionTranslator* et);
 
-    template <bool C>
-    struct StringStreamBase
-    {
-        template <typename T>
-        static void convert(std::ostream* s, const T& in) {
-            *s << toString(in);
-        }
-
-        // always treat char* as a string in this context - no matter
-        // if DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING is defined
-        static void convert(std::ostream* s, const char* in) { *s << String(in); }
-    };
-
-    template <>
-    struct StringStreamBase<true>
-    {
-        template <typename T>
-        static void convert(std::ostream* s, const T& in) {
-            *s << in;
-        }
-    };
-
-    template <typename T>
-    struct StringStream : public StringStreamBase<has_insertion_operator<T>::value>
-    {};
-
-    template <typename T>
-    void toStream(std::ostream* s, const T& value) {
-        StringStream<T>::convert(s, value);
-    }
-
-#ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    DOCTEST_INTERFACE void toStream(std::ostream* s, char* in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, const char* in);
-#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    DOCTEST_INTERFACE void toStream(std::ostream* s, bool in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, float in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, double in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, double long in);
-
-    DOCTEST_INTERFACE void toStream(std::ostream* s, char in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, char signed in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, char unsigned in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, int short in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, int short unsigned in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, int in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, int unsigned in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, int long in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, int long unsigned in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, int long long in);
-    DOCTEST_INTERFACE void toStream(std::ostream* s, int long long unsigned in);
-
-    // ContextScope base class used to allow implementing methods of ContextScope 
+    // ContextScope base class used to allow implementing methods of ContextScope
     // that don't depend on the template parameter in doctest.cpp.
-    class DOCTEST_INTERFACE ContextScopeBase : public IContextScope {
+    struct DOCTEST_INTERFACE ContextScopeBase : public IContextScope {
+        ContextScopeBase(const ContextScopeBase&) = delete;
+
+        ContextScopeBase& operator=(const ContextScopeBase&) = delete;
+        ContextScopeBase& operator=(ContextScopeBase&&) = delete;
+
+        ~ContextScopeBase() override = default;
+
     protected:
         ContextScopeBase();
+        ContextScopeBase(ContextScopeBase&& other) noexcept;
 
         void destroy();
+        bool need_to_destroy{true};
     };
 
-    template <typename L> class DOCTEST_INTERFACE ContextScope : public ContextScopeBase
+    template <typename L> class ContextScope : public ContextScopeBase
     {
-        const L &lambda_;
+        L lambda_;
 
     public:
         explicit ContextScope(const L &lambda) : lambda_(lambda) {}
+        explicit ContextScope(L&& lambda) : lambda_(static_cast<L&&>(lambda)) { }
 
-        ContextScope(ContextScope &&other) : lambda_(other.lambda_) {}
+        ContextScope(const ContextScope&) = delete;
+        ContextScope(ContextScope&&) noexcept = default;
+
+        ContextScope& operator=(const ContextScope&) = delete;
+        ContextScope& operator=(ContextScope&&) = delete;
 
         void stringify(std::ostream* s) const override { lambda_(s); }
 
-        ~ContextScope() override { destroy(); }
+        ~ContextScope() override {
+            if (need_to_destroy) {
+                destroy();
+            }
+        }
     };
 
     struct DOCTEST_INTERFACE MessageBuilder : public MessageData
     {
         std::ostream* m_stream;
+        bool          logged = false;
 
         MessageBuilder(const char* file, int line, assertType::Enum severity);
-        MessageBuilder() = delete;
+
+        MessageBuilder(const MessageBuilder&) = delete;
+        MessageBuilder(MessageBuilder&&) = delete;
+
+        MessageBuilder& operator=(const MessageBuilder&) = delete;
+        MessageBuilder& operator=(MessageBuilder&&) = delete;
+
         ~MessageBuilder();
 
-        DOCTEST_DELETE_COPIES(MessageBuilder);
-
+        // the preferred way of chaining parameters for stringification
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4866)
         template <typename T>
-        MessageBuilder& operator<<(const T& in) {
-            toStream(m_stream, in);
+        MessageBuilder& operator,(const T& in) {
+            *m_stream << (DOCTEST_STRINGIFY(in));
             return *this;
         }
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+
+        // kept here just for backwards-compatibility - the comma operator should be preferred now
+        template <typename T>
+        MessageBuilder& operator<<(const T& in) { return this->operator,(in); }
+
+        // the `,` operator has the lowest operator precedence - if `<<` is used by the user then
+        // the `,` operator will be called last which is not what we want and thus the `*` operator
+        // is used first (has higher operator precedence compared to `<<`) so that we guarantee that
+        // an operator of the MessageBuilder class is called first before the rest of the parameters
+        template <typename T>
+        MessageBuilder& operator*(const T& in) { return this->operator,(in); }
 
         bool log();
         void react();
     };
-    
+
     template <typename L>
     ContextScope<L> MakeContextScope(const L &lambda) {
         return ContextScope<L>(lambda);
@@ -1590,6 +1882,8 @@ namespace detail {
 DOCTEST_DEFINE_DECORATOR(test_suite, const char*, "");
 DOCTEST_DEFINE_DECORATOR(description, const char*, "");
 DOCTEST_DEFINE_DECORATOR(skip, bool, true);
+DOCTEST_DEFINE_DECORATOR(no_breaks, bool, true);
+DOCTEST_DEFINE_DECORATOR(no_output, bool, true);
 DOCTEST_DEFINE_DECORATOR(timeout, double, 0);
 DOCTEST_DEFINE_DECORATOR(may_fail, bool, true);
 DOCTEST_DEFINE_DECORATOR(should_fail, bool, true);
@@ -1621,7 +1915,7 @@ int registerExceptionTranslator(String (*)(T)) {
 #endif // DOCTEST_CONFIG_DISABLE
 
 namespace detail {
-    typedef void (*assert_handler)(const AssertData&);
+    using assert_handler = void (*)(const AssertData&);
     struct ContextState;
 } // namespace detail
 
@@ -1634,14 +1928,19 @@ class DOCTEST_INTERFACE Context
 public:
     explicit Context(int argc = 0, const char* const* argv = nullptr);
 
-    DOCTEST_DELETE_COPIES(Context);
+    Context(const Context&) = delete;
+    Context(Context&&) = delete;
 
-    ~Context();
+    Context& operator=(const Context&) = delete;
+    Context& operator=(Context&&) = delete;
+
+    ~Context(); // NOLINT(performance-trivially-destructible)
 
     void applyCommandLine(int argc, const char* const* argv);
 
     void addFilter(const char* filter, const char* value);
     void clearFilters();
+    void setOption(const char* option, bool value);
     void setOption(const char* option, int value);
     void setOption(const char* option, const char* value);
 
@@ -1650,6 +1949,8 @@ public:
     void setAsDefaultForAssertsOutOfTestCases();
 
     void setAssertHandler(detail::assert_handler ah);
+
+    void setCout(std::ostream* out);
 
     int run();
 };
@@ -1677,9 +1978,7 @@ struct DOCTEST_INTERFACE CurrentTestCaseStats
     int    numAssertsFailedCurrentTest;
     double seconds;
     int    failure_flags; // use TestCaseFailureReason::Enum
-
-    DOCTEST_DECLARE_DEFAULTS(CurrentTestCaseStats);
-    DOCTEST_DELETE_COPIES(CurrentTestCaseStats);
+    bool   testCaseSuccess;
 };
 
 struct DOCTEST_INTERFACE TestCaseException
@@ -1696,16 +1995,13 @@ struct DOCTEST_INTERFACE TestRunStats
     unsigned numTestCasesFailed;
     int      numAsserts;
     int      numAssertsFailed;
-
-    DOCTEST_DECLARE_DEFAULTS(TestRunStats);
-    DOCTEST_DELETE_COPIES(TestRunStats);
 };
 
 struct QueryData
 {
-    const TestRunStats* run_stats = nullptr;
-    String*             data      = nullptr;
-    unsigned            num_data  = 0;
+    const TestRunStats*  run_stats = nullptr;
+    const TestCaseData** data      = nullptr;
+    unsigned             num_data  = 0;
 };
 
 struct DOCTEST_INTERFACE IReporter
@@ -1724,6 +2020,8 @@ struct DOCTEST_INTERFACE IReporter
 
     // called when a test case is started (safe to cache a pointer to the input)
     virtual void test_case_start(const TestCaseData&) = 0;
+    // called when a test case is reentered because of unfinished subcases (safe to cache a pointer to the input)
+    virtual void test_case_reenter(const TestCaseData&) = 0;
     // called when a test case has ended
     virtual void test_case_end(const CurrentTestCaseStats&) = 0;
 
@@ -1744,8 +2042,7 @@ struct DOCTEST_INTERFACE IReporter
     // or isn't in the execution range (between first and last) (safe to cache a pointer to the input)
     virtual void test_case_skipped(const TestCaseData&) = 0;
 
-    // doctest will not be managing the lifetimes of reporters given to it but this would still be nice to have
-    virtual ~IReporter();
+    DOCTEST_DECLARE_INTERFACE(IReporter)
 
     // can obtain all currently active contexts and stringify them if one wishes to do so
     static int                         get_num_active_contexts();
@@ -1757,7 +2054,7 @@ struct DOCTEST_INTERFACE IReporter
 };
 
 namespace detail {
-    typedef IReporter* (*reporterCreatorFunc)(const ContextOptions&);
+    using reporterCreatorFunc =  IReporter* (*)(const ContextOptions&);
 
     DOCTEST_INTERFACE void registerReporterImpl(const char* name, int prio, reporterCreatorFunc c, bool isReporter);
 
@@ -1774,14 +2071,30 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 }
 } // namespace doctest
 
+#ifdef DOCTEST_CONFIG_ASSERTS_RETURN_VALUES
+#define DOCTEST_FUNC_EMPTY [] { return false; }()
+#else
+#define DOCTEST_FUNC_EMPTY (void)0
+#endif
+
 // if registering is not disabled
-#if !defined(DOCTEST_CONFIG_DISABLE)
+#ifndef DOCTEST_CONFIG_DISABLE
+
+#ifdef DOCTEST_CONFIG_ASSERTS_RETURN_VALUES
+#define DOCTEST_FUNC_SCOPE_BEGIN [&]
+#define DOCTEST_FUNC_SCOPE_END ()
+#define DOCTEST_FUNC_SCOPE_RET(v) return v
+#else
+#define DOCTEST_FUNC_SCOPE_BEGIN do
+#define DOCTEST_FUNC_SCOPE_END while(false)
+#define DOCTEST_FUNC_SCOPE_RET(v) (void)0
+#endif
 
 // common code in asserts - for convenience
-#define DOCTEST_ASSERT_LOG_AND_REACT(b)                                                            \
-    if(b.log())                                                                                    \
-        DOCTEST_BREAK_INTO_DEBUGGER();                                                             \
-    b.react()
+#define DOCTEST_ASSERT_LOG_REACT_RETURN(b)                                                         \
+    if(b.log()) DOCTEST_BREAK_INTO_DEBUGGER();                                                     \
+    b.react();                                                                                     \
+    DOCTEST_FUNC_SCOPE_RET(!b.m_failed)
 
 #ifdef DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 #define DOCTEST_WRAP_IN_TRY(x) x;
@@ -1789,41 +2102,40 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 #define DOCTEST_WRAP_IN_TRY(x)                                                                     \
     try {                                                                                          \
         x;                                                                                         \
-    } catch(...) { _DOCTEST_RB.translateException(); }
+    } catch(...) { DOCTEST_RB.translateException(); }
 #endif // DOCTEST_CONFIG_NO_TRY_CATCH_IN_ASSERTS
 
 #ifdef DOCTEST_CONFIG_VOID_CAST_EXPRESSIONS
-#define DOCTEST_CAST_TO_VOID(x)                                                                    \
+#define DOCTEST_CAST_TO_VOID(...)                                                                  \
     DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wuseless-cast")                                       \
-    static_cast<void>(x);                                                                          \
+    static_cast<void>(__VA_ARGS__);                                                                \
     DOCTEST_GCC_SUPPRESS_WARNING_POP
 #else // DOCTEST_CONFIG_VOID_CAST_EXPRESSIONS
-#define DOCTEST_CAST_TO_VOID(x) x;
+#define DOCTEST_CAST_TO_VOID(...) __VA_ARGS__;
 #endif // DOCTEST_CONFIG_VOID_CAST_EXPRESSIONS
 
 // registers the test by initializing a dummy var with a function
 #define DOCTEST_REGISTER_FUNCTION(global_prefix, f, decorators)                                    \
-    global_prefix DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) =              \
+    global_prefix DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT */    \
             doctest::detail::regTest(                                                              \
                     doctest::detail::TestCase(                                                     \
                             f, __FILE__, __LINE__,                                                 \
                             doctest_detail_test_suite_ns::getCurrentTestSuite()) *                 \
-                    decorators);                                                                   \
-    DOCTEST_GLOBAL_NO_WARNINGS_END()
+                    decorators))
 
 #define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, decorators)                                     \
-    namespace {                                                                                    \
+    namespace { /* NOLINT */                                                                       \
         struct der : public base                                                                   \
         {                                                                                          \
             void f();                                                                              \
         };                                                                                         \
-        static void func() {                                                                       \
+        static inline DOCTEST_NOINLINE void func() {                                               \
             der v;                                                                                 \
             v.f();                                                                                 \
         }                                                                                          \
         DOCTEST_REGISTER_FUNCTION(DOCTEST_EMPTY, func, decorators)                                 \
     }                                                                                              \
-    inline DOCTEST_NOINLINE void der::f()
+    inline DOCTEST_NOINLINE void der::f() // NOLINT(misc-definitions-in-headers)
 
 #define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, decorators)                                        \
     static void f();                                                                               \
@@ -1832,18 +2144,18 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 
 #define DOCTEST_CREATE_AND_REGISTER_FUNCTION_IN_CLASS(f, proxy, decorators)                        \
     static doctest::detail::funcType proxy() { return f; }                                         \
-    DOCTEST_REGISTER_FUNCTION(inline const, proxy(), decorators)                                   \
+    DOCTEST_REGISTER_FUNCTION(inline, proxy(), decorators)                                         \
     static void f()
 
 // for registering tests
 #define DOCTEST_TEST_CASE(decorators)                                                              \
-    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), decorators)
+    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), decorators)
 
 // for registering tests in classes - requires C++17 for inline variables!
-#if __cplusplus >= 201703L || (DOCTEST_MSVC >= DOCTEST_COMPILER(19, 12, 0) && _MSVC_LANG >= 201703L)
+#if DOCTEST_CPLUSPLUS >= 201703L
 #define DOCTEST_TEST_CASE_CLASS(decorators)                                                        \
-    DOCTEST_CREATE_AND_REGISTER_FUNCTION_IN_CLASS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_),          \
-                                                  DOCTEST_ANONYMOUS(_DOCTEST_ANON_PROXY_),         \
+    DOCTEST_CREATE_AND_REGISTER_FUNCTION_IN_CLASS(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_),           \
+                                                  DOCTEST_ANONYMOUS(DOCTEST_ANON_PROXY_),          \
                                                   decorators)
 #else // DOCTEST_TEST_CASE_CLASS
 #define DOCTEST_TEST_CASE_CLASS(...)                                                               \
@@ -1852,26 +2164,25 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 
 // for registering tests with a fixture
 #define DOCTEST_TEST_CASE_FIXTURE(c, decorators)                                                   \
-    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(_DOCTEST_ANON_CLASS_), c,                          \
-                              DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), decorators)
+    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(DOCTEST_ANON_CLASS_), c,                           \
+                              DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), decorators)
 
 // for converting types to strings without the <typeinfo> header and demangling
-#define DOCTEST_TYPE_TO_STRING_IMPL(...)                                                           \
-    template <>                                                                                    \
-    inline const char* type_to_string<__VA_ARGS__>() {                                             \
-        return "<" #__VA_ARGS__ ">";                                                               \
-    }
-#define DOCTEST_TYPE_TO_STRING(...)                                                                \
-    namespace doctest { namespace detail {                                                         \
-            DOCTEST_TYPE_TO_STRING_IMPL(__VA_ARGS__)                                               \
+#define DOCTEST_TYPE_TO_STRING_AS(str, ...)                                                        \
+    namespace doctest {                                                                            \
+        template <>                                                                                \
+        inline String toString<__VA_ARGS__>() {                                                    \
+            return str;                                                                            \
         }                                                                                          \
     }                                                                                              \
-    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+    static_assert(true, "")
+
+#define DOCTEST_TYPE_TO_STRING(...) DOCTEST_TYPE_TO_STRING_AS(#__VA_ARGS__, __VA_ARGS__)
 
 #define DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, iter, func)                                 \
     template <typename T>                                                                          \
     static void func();                                                                            \
-    namespace {                                                                                    \
+    namespace { /* NOLINT */                                                                       \
         template <typename Tuple>                                                                  \
         struct iter;                                                                               \
         template <typename Type, typename... Rest>                                                 \
@@ -1880,7 +2191,7 @@ int registerReporter(const char* name, int priority, bool isReporter) {
             iter(const char* file, unsigned line, int index) {                                     \
                 doctest::detail::regTest(doctest::detail::TestCase(func<Type>, file, line,         \
                                             doctest_detail_test_suite_ns::getCurrentTestSuite(),   \
-                                            doctest::detail::type_to_string<Type>(),               \
+                                            doctest::toString<Type>(),                             \
                                             int(line) * 1000 + index)                              \
                                          * dec);                                                   \
                 iter<std::tuple<Rest...>>(file, line, index + 1);                                  \
@@ -1897,20 +2208,20 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 
 #define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(dec, T, id)                                              \
     DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, DOCTEST_CAT(id, ITERATOR),                      \
-                                           DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_))
+                                           DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_))
 
 #define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, anon, ...)                                 \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY)) =                                         \
-        doctest::detail::instantiationHelper(DOCTEST_CAT(id, ITERATOR)<__VA_ARGS__>(__FILE__, __LINE__, 0));\
-    DOCTEST_GLOBAL_NO_WARNINGS_END()
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_CAT(anon, DUMMY), /* NOLINT(cert-err58-cpp, fuchsia-statically-constructed-objects) */ \
+        doctest::detail::instantiationHelper(                                                      \
+            DOCTEST_CAT(id, ITERATOR)<__VA_ARGS__>(__FILE__, __LINE__, 0)))
 
 #define DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, ...)                                                 \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_), std::tuple<__VA_ARGS__>) \
-    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), std::tuple<__VA_ARGS__>) \
+    static_assert(true, "")
 
 #define DOCTEST_TEST_CASE_TEMPLATE_APPLY(id, ...)                                                  \
-    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_), __VA_ARGS__) \
-    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+    DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE_IMPL(id, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), __VA_ARGS__) \
+    static_assert(true, "")
 
 #define DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, anon, ...)                                         \
     DOCTEST_TEST_CASE_TEMPLATE_DEFINE_IMPL(dec, T, DOCTEST_CAT(anon, ITERATOR), anon);             \
@@ -1919,23 +2230,25 @@ int registerReporter(const char* name, int priority, bool isReporter) {
     static void anon()
 
 #define DOCTEST_TEST_CASE_TEMPLATE(dec, T, ...)                                                    \
-    DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_), __VA_ARGS__)
+    DOCTEST_TEST_CASE_TEMPLATE_IMPL(dec, T, DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_), __VA_ARGS__)
 
 // for subcases
 #define DOCTEST_SUBCASE(name)                                                                      \
-    if(const doctest::detail::Subcase & DOCTEST_ANONYMOUS(_DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED = \
+    if(const doctest::detail::Subcase & DOCTEST_ANONYMOUS(DOCTEST_ANON_SUBCASE_) DOCTEST_UNUSED =  \
                doctest::detail::Subcase(name, __FILE__, __LINE__))
 
 // for grouping tests in test suites by using code blocks
 #define DOCTEST_TEST_SUITE_IMPL(decorators, ns_name)                                               \
     namespace ns_name { namespace doctest_detail_test_suite_ns {                                   \
-            static DOCTEST_NOINLINE doctest::detail::TestSuite& getCurrentTestSuite() {            \
+            static DOCTEST_NOINLINE doctest::detail::TestSuite& getCurrentTestSuite() noexcept {   \
                 DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4640)                                      \
                 DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wexit-time-destructors")                \
-                static doctest::detail::TestSuite data;                                            \
+                DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wmissing-field-initializers")             \
+                static doctest::detail::TestSuite data{};                                          \
                 static bool                       inited = false;                                  \
                 DOCTEST_MSVC_SUPPRESS_WARNING_POP                                                  \
                 DOCTEST_CLANG_SUPPRESS_WARNING_POP                                                 \
+                DOCTEST_GCC_SUPPRESS_WARNING_POP                                                   \
                 if(!inited) {                                                                      \
                     data* decorators;                                                              \
                     inited = true;                                                                 \
@@ -1947,79 +2260,79 @@ int registerReporter(const char* name, int priority, bool isReporter) {
     namespace ns_name
 
 #define DOCTEST_TEST_SUITE(decorators)                                                             \
-    DOCTEST_TEST_SUITE_IMPL(decorators, DOCTEST_ANONYMOUS(_DOCTEST_ANON_SUITE_))
+    DOCTEST_TEST_SUITE_IMPL(decorators, DOCTEST_ANONYMOUS(DOCTEST_ANON_SUITE_))
 
 // for starting a testsuite block
 #define DOCTEST_TEST_SUITE_BEGIN(decorators)                                                       \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) =                            \
-            doctest::detail::setTestSuite(doctest::detail::TestSuite() * decorators);              \
-    DOCTEST_GLOBAL_NO_WARNINGS_END()                                                               \
-    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */  \
+            doctest::detail::setTestSuite(doctest::detail::TestSuite() * decorators))              \
+    static_assert(true, "")
 
 // for ending a testsuite block
 #define DOCTEST_TEST_SUITE_END                                                                     \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_VAR_)) =                            \
-            doctest::detail::setTestSuite(doctest::detail::TestSuite() * "");                      \
-    DOCTEST_GLOBAL_NO_WARNINGS_END()                                                               \
-    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_VAR_), /* NOLINT(cert-err58-cpp) */  \
+            doctest::detail::setTestSuite(doctest::detail::TestSuite() * ""))                      \
+    using DOCTEST_ANONYMOUS(DOCTEST_ANON_FOR_SEMICOLON_) = int
 
 // for registering exception translators
 #define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(translatorName, signature)                      \
     inline doctest::String translatorName(signature);                                              \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_)) =                     \
-            doctest::registerExceptionTranslator(translatorName);                                  \
-    DOCTEST_GLOBAL_NO_WARNINGS_END()                                                               \
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_), /* NOLINT(cert-err58-cpp) */ \
+            doctest::registerExceptionTranslator(translatorName))                                  \
     doctest::String translatorName(signature)
 
 #define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                           \
-    DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_),       \
+    DOCTEST_REGISTER_EXCEPTION_TRANSLATOR_IMPL(DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_),        \
                                                signature)
 
 // for registering reporters
 #define DOCTEST_REGISTER_REPORTER(name, priority, reporter)                                        \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_REPORTER_)) =                       \
-            doctest::registerReporter<reporter>(name, priority, true);                             \
-    DOCTEST_GLOBAL_NO_WARNINGS_END() typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */ \
+            doctest::registerReporter<reporter>(name, priority, true))                             \
+    static_assert(true, "")
 
 // for registering listeners
 #define DOCTEST_REGISTER_LISTENER(name, priority, reporter)                                        \
-    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(_DOCTEST_ANON_REPORTER_)) =                       \
-            doctest::registerReporter<reporter>(name, priority, false);                            \
-    DOCTEST_GLOBAL_NO_WARNINGS_END() typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-
-// for logging
-#define DOCTEST_INFO(expression)                                                                   \
-    DOCTEST_INFO_IMPL(DOCTEST_ANONYMOUS(_DOCTEST_CAPTURE_), DOCTEST_ANONYMOUS(_DOCTEST_CAPTURE_),  \
-                      DOCTEST_ANONYMOUS(_DOCTEST_CAPTURE_), expression)
-
-#define DOCTEST_INFO_IMPL(lambda_name, mb_name, s_name, expression)                                \
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4626)                                                  \
-    auto lambda_name = [&](std::ostream* s_name) {                                                 \
-        doctest::detail::MessageBuilder mb_name(__FILE__, __LINE__, doctest::assertType::is_warn); \
-        mb_name.m_stream = s_name;                                                                 \
-        mb_name << expression;                                                                     \
-    };                                                                                             \
-    DOCTEST_MSVC_SUPPRESS_WARNING_POP                                                              \
-    auto DOCTEST_ANONYMOUS(_DOCTEST_CAPTURE_) = doctest::detail::MakeContextScope(lambda_name)
-
-#define DOCTEST_CAPTURE(x) DOCTEST_INFO(#x " := " << x)
-
-#define DOCTEST_ADD_AT_IMPL(type, file, line, mb, x)                                               \
-    do {                                                                                           \
-        doctest::detail::MessageBuilder mb(file, line, doctest::assertType::type);                 \
-        mb << x;                                                                                   \
-        DOCTEST_ASSERT_LOG_AND_REACT(mb);                                                          \
-    } while((void)0, 0)
+    DOCTEST_GLOBAL_NO_WARNINGS(DOCTEST_ANONYMOUS(DOCTEST_ANON_REPORTER_), /* NOLINT(cert-err58-cpp) */ \
+            doctest::registerReporter<reporter>(name, priority, false))                            \
+    static_assert(true, "")
 
 // clang-format off
-#define DOCTEST_ADD_MESSAGE_AT(file, line, x) DOCTEST_ADD_AT_IMPL(is_warn, file, line, DOCTEST_ANONYMOUS(_DOCTEST_MESSAGE_), x)
-#define DOCTEST_ADD_FAIL_CHECK_AT(file, line, x) DOCTEST_ADD_AT_IMPL(is_check, file, line, DOCTEST_ANONYMOUS(_DOCTEST_MESSAGE_), x)
-#define DOCTEST_ADD_FAIL_AT(file, line, x) DOCTEST_ADD_AT_IMPL(is_require, file, line, DOCTEST_ANONYMOUS(_DOCTEST_MESSAGE_), x)
+// for logging - disabling formatting because it's important to have these on 2 separate lines - see PR #557
+#define DOCTEST_INFO(...)                                                                          \
+    DOCTEST_INFO_IMPL(DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_),                                         \
+                      DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_OTHER_),                                   \
+                      __VA_ARGS__)
 // clang-format on
 
-#define DOCTEST_MESSAGE(x) DOCTEST_ADD_MESSAGE_AT(__FILE__, __LINE__, x)
-#define DOCTEST_FAIL_CHECK(x) DOCTEST_ADD_FAIL_CHECK_AT(__FILE__, __LINE__, x)
-#define DOCTEST_FAIL(x) DOCTEST_ADD_FAIL_AT(__FILE__, __LINE__, x)
+#define DOCTEST_INFO_IMPL(mb_name, s_name, ...)                                       \
+    auto DOCTEST_ANONYMOUS(DOCTEST_CAPTURE_) = doctest::detail::MakeContextScope(                  \
+        [&](std::ostream* s_name) {                                                                \
+        doctest::detail::MessageBuilder mb_name(__FILE__, __LINE__, doctest::assertType::is_warn); \
+        mb_name.m_stream = s_name;                                                                 \
+        mb_name * __VA_ARGS__;                                                                     \
+    })
+
+#define DOCTEST_CAPTURE(x) DOCTEST_INFO(#x " := ", x)
+
+#define DOCTEST_ADD_AT_IMPL(type, file, line, mb, ...)                                             \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
+        doctest::detail::MessageBuilder mb(file, line, doctest::assertType::type);                 \
+        mb * __VA_ARGS__;                                                                          \
+        if(mb.log())                                                                               \
+            DOCTEST_BREAK_INTO_DEBUGGER();                                                         \
+        mb.react();                                                                                \
+    } DOCTEST_FUNC_SCOPE_END
+
+// clang-format off
+#define DOCTEST_ADD_MESSAGE_AT(file, line, ...) DOCTEST_ADD_AT_IMPL(is_warn, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
+#define DOCTEST_ADD_FAIL_CHECK_AT(file, line, ...) DOCTEST_ADD_AT_IMPL(is_check, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
+#define DOCTEST_ADD_FAIL_AT(file, line, ...) DOCTEST_ADD_AT_IMPL(is_require, file, line, DOCTEST_ANONYMOUS(DOCTEST_MESSAGE_), __VA_ARGS__)
+// clang-format on
+
+#define DOCTEST_MESSAGE(...) DOCTEST_ADD_MESSAGE_AT(__FILE__, __LINE__, __VA_ARGS__)
+#define DOCTEST_FAIL_CHECK(...) DOCTEST_ADD_FAIL_CHECK_AT(__FILE__, __LINE__, __VA_ARGS__)
+#define DOCTEST_FAIL(...) DOCTEST_ADD_FAIL_AT(__FILE__, __LINE__, __VA_ARGS__)
 
 #define DOCTEST_TO_LVALUE(...) __VA_ARGS__ // Not removed to keep backwards compatibility.
 
@@ -2027,20 +2340,42 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 
 #define DOCTEST_ASSERT_IMPLEMENT_2(assert_type, ...)                                               \
     DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                  \
-    doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__,         \
+    /* NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) */                                  \
+    doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,          \
                                                __LINE__, #__VA_ARGS__);                            \
-    DOCTEST_WRAP_IN_TRY(_DOCTEST_RB.setResult(                                                     \
+    DOCTEST_WRAP_IN_TRY(DOCTEST_RB.setResult(                                                      \
             doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type)                \
-            << __VA_ARGS__))                                                                       \
-    DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB)                                                      \
+            << __VA_ARGS__)) /* NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks) */         \
+    DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB)                                                    \
     DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
 #define DOCTEST_ASSERT_IMPLEMENT_1(assert_type, ...)                                               \
-    do {                                                                                           \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
         DOCTEST_ASSERT_IMPLEMENT_2(assert_type, __VA_ARGS__);                                      \
-    } while((void)0, 0)
+    } DOCTEST_FUNC_SCOPE_END // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+
+#define DOCTEST_BINARY_ASSERT(assert_type, comp, ...)                                              \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
+        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,      \
+                                                   __LINE__, #__VA_ARGS__);                        \
+        DOCTEST_WRAP_IN_TRY(                                                                       \
+                DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(           \
+                        __VA_ARGS__))                                                              \
+        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                               \
+    } DOCTEST_FUNC_SCOPE_END
+
+#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                     \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
+        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,      \
+                                                   __LINE__, #__VA_ARGS__);                        \
+        DOCTEST_WRAP_IN_TRY(DOCTEST_RB.unary_assert(__VA_ARGS__))                                  \
+        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                               \
+    } DOCTEST_FUNC_SCOPE_END
 
 #else // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
+
+// necessary for <ASSERT>_MESSAGE
+#define DOCTEST_ASSERT_IMPLEMENT_2 DOCTEST_ASSERT_IMPLEMENT_1
 
 #define DOCTEST_ASSERT_IMPLEMENT_1(assert_type, ...)                                               \
     DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Woverloaded-shift-op-parentheses")                  \
@@ -2048,6 +2383,14 @@ int registerReporter(const char* name, int priority, bool isReporter) {
             doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__,                    \
             doctest::detail::ExpressionDecomposer(doctest::assertType::assert_type)                \
                     << __VA_ARGS__) DOCTEST_CLANG_SUPPRESS_WARNING_POP
+
+#define DOCTEST_BINARY_ASSERT(assert_type, comparison, ...)                                        \
+    doctest::detail::binary_assert<doctest::detail::binaryAssertComparison::comparison>(           \
+            doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__, __VA_ARGS__)
+
+#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                     \
+    doctest::detail::unary_assert(doctest::assertType::assert_type, __FILE__, __LINE__,            \
+                                  #__VA_ARGS__, __VA_ARGS__)
 
 #endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
@@ -2059,114 +2402,13 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 #define DOCTEST_REQUIRE_FALSE(...) DOCTEST_ASSERT_IMPLEMENT_1(DT_REQUIRE_FALSE, __VA_ARGS__)
 
 // clang-format off
-#define DOCTEST_WARN_MESSAGE(cond, msg) do { DOCTEST_INFO(msg); DOCTEST_ASSERT_IMPLEMENT_2(DT_WARN, cond); } while((void)0, 0)
-#define DOCTEST_CHECK_MESSAGE(cond, msg) do { DOCTEST_INFO(msg); DOCTEST_ASSERT_IMPLEMENT_2(DT_CHECK, cond); } while((void)0, 0)
-#define DOCTEST_REQUIRE_MESSAGE(cond, msg) do { DOCTEST_INFO(msg); DOCTEST_ASSERT_IMPLEMENT_2(DT_REQUIRE, cond); } while((void)0, 0)
-#define DOCTEST_WARN_FALSE_MESSAGE(cond, msg) do { DOCTEST_INFO(msg); DOCTEST_ASSERT_IMPLEMENT_2(DT_WARN_FALSE, cond); } while((void)0, 0)
-#define DOCTEST_CHECK_FALSE_MESSAGE(cond, msg) do { DOCTEST_INFO(msg); DOCTEST_ASSERT_IMPLEMENT_2(DT_CHECK_FALSE, cond); } while((void)0, 0)
-#define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, msg) do { DOCTEST_INFO(msg); DOCTEST_ASSERT_IMPLEMENT_2(DT_REQUIRE_FALSE, cond); } while((void)0, 0)
+#define DOCTEST_WARN_MESSAGE(cond, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_ASSERT_IMPLEMENT_2(DT_WARN, cond); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_MESSAGE(cond, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_ASSERT_IMPLEMENT_2(DT_CHECK, cond); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_MESSAGE(cond, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_ASSERT_IMPLEMENT_2(DT_REQUIRE, cond); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_WARN_FALSE_MESSAGE(cond, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_ASSERT_IMPLEMENT_2(DT_WARN_FALSE, cond); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_FALSE_MESSAGE(cond, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_ASSERT_IMPLEMENT_2(DT_CHECK_FALSE, cond); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_ASSERT_IMPLEMENT_2(DT_REQUIRE_FALSE, cond); } DOCTEST_FUNC_SCOPE_END
 // clang-format on
-
-#define DOCTEST_ASSERT_THROWS_AS(expr, assert_type, ...)                                           \
-    do {                                                                                           \
-        if(!doctest::getContextOptions()->no_throw) {                                              \
-            doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__, \
-                                                       __LINE__, #expr, #__VA_ARGS__);             \
-            try {                                                                                  \
-                DOCTEST_CAST_TO_VOID(expr)                                                         \
-            } catch(const doctest::detail::remove_const<                                           \
-                    doctest::detail::remove_reference<__VA_ARGS__>::type>::type&) {                \
-                _DOCTEST_RB.translateException();                                                  \
-                _DOCTEST_RB.m_threw_as = true;                                                     \
-            } catch(...) { _DOCTEST_RB.translateException(); }                                     \
-            DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                             \
-        }                                                                                          \
-    } while((void)0, 0)
-
-#define DOCTEST_ASSERT_THROWS_WITH(expr, assert_type, ...)                                         \
-    do {                                                                                           \
-        if(!doctest::getContextOptions()->no_throw) {                                              \
-            doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__, \
-                                                       __LINE__, #expr, __VA_ARGS__);              \
-            try {                                                                                  \
-                DOCTEST_CAST_TO_VOID(expr)                                                         \
-            } catch(...) { _DOCTEST_RB.translateException(); }                                     \
-            DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                             \
-        }                                                                                          \
-    } while((void)0, 0)
-
-#define DOCTEST_ASSERT_NOTHROW(expr, assert_type)                                                  \
-    do {                                                                                           \
-        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__,     \
-                                                   __LINE__, #expr);                               \
-        try {                                                                                      \
-            DOCTEST_CAST_TO_VOID(expr)                                                             \
-        } catch(...) { _DOCTEST_RB.translateException(); }                                         \
-        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                 \
-    } while((void)0, 0)
-
-// clang-format off
-#define DOCTEST_WARN_THROWS(expr) DOCTEST_ASSERT_THROWS_WITH(expr, DT_WARN_THROWS, "")
-#define DOCTEST_CHECK_THROWS(expr) DOCTEST_ASSERT_THROWS_WITH(expr, DT_CHECK_THROWS, "")
-#define DOCTEST_REQUIRE_THROWS(expr) DOCTEST_ASSERT_THROWS_WITH(expr, DT_REQUIRE_THROWS, "")
-
-#define DOCTEST_WARN_THROWS_AS(expr, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_WARN_THROWS_AS, __VA_ARGS__)
-#define DOCTEST_CHECK_THROWS_AS(expr, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_CHECK_THROWS_AS, __VA_ARGS__)
-#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_REQUIRE_THROWS_AS, __VA_ARGS__)
-
-#define DOCTEST_WARN_THROWS_WITH(expr, ...) DOCTEST_ASSERT_THROWS_WITH(expr, DT_WARN_THROWS_WITH, __VA_ARGS__)
-#define DOCTEST_CHECK_THROWS_WITH(expr, ...) DOCTEST_ASSERT_THROWS_WITH(expr, DT_CHECK_THROWS_WITH, __VA_ARGS__)
-#define DOCTEST_REQUIRE_THROWS_WITH(expr, ...) DOCTEST_ASSERT_THROWS_WITH(expr, DT_REQUIRE_THROWS_WITH, __VA_ARGS__)
-
-#define DOCTEST_WARN_NOTHROW(expr) DOCTEST_ASSERT_NOTHROW(expr, DT_WARN_NOTHROW)
-#define DOCTEST_CHECK_NOTHROW(expr) DOCTEST_ASSERT_NOTHROW(expr, DT_CHECK_NOTHROW)
-#define DOCTEST_REQUIRE_NOTHROW(expr) DOCTEST_ASSERT_NOTHROW(expr, DT_REQUIRE_NOTHROW)
-
-#define DOCTEST_WARN_THROWS_MESSAGE(expr, msg) do { DOCTEST_INFO(msg); DOCTEST_WARN_THROWS(expr); } while((void)0, 0)
-#define DOCTEST_CHECK_THROWS_MESSAGE(expr, msg) do { DOCTEST_INFO(msg); DOCTEST_CHECK_THROWS(expr); } while((void)0, 0)
-#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, msg) do { DOCTEST_INFO(msg); DOCTEST_REQUIRE_THROWS(expr); } while((void)0, 0)
-#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, msg) do { DOCTEST_INFO(msg); DOCTEST_WARN_THROWS_AS(expr, ex); } while((void)0, 0)
-#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, msg) do { DOCTEST_INFO(msg); DOCTEST_CHECK_THROWS_AS(expr, ex); } while((void)0, 0)
-#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, msg) do { DOCTEST_INFO(msg); DOCTEST_REQUIRE_THROWS_AS(expr, ex); } while((void)0, 0)
-#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, ex, msg) do { DOCTEST_INFO(msg); DOCTEST_WARN_THROWS_WITH(expr, ex); } while((void)0, 0)
-#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, ex, msg) do { DOCTEST_INFO(msg); DOCTEST_CHECK_THROWS_WITH(expr, ex); } while((void)0, 0)
-#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, ex, msg) do { DOCTEST_INFO(msg); DOCTEST_REQUIRE_THROWS_WITH(expr, ex); } while((void)0, 0)
-#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, msg) do { DOCTEST_INFO(msg); DOCTEST_WARN_NOTHROW(expr); } while((void)0, 0)
-#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, msg) do { DOCTEST_INFO(msg); DOCTEST_CHECK_NOTHROW(expr); } while((void)0, 0)
-#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, msg) do { DOCTEST_INFO(msg); DOCTEST_REQUIRE_NOTHROW(expr); } while((void)0, 0)
-// clang-format on
-
-#ifndef DOCTEST_CONFIG_SUPER_FAST_ASSERTS
-
-#define DOCTEST_BINARY_ASSERT(assert_type, comp, ...)                                              \
-    do {                                                                                           \
-        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__,     \
-                                                   __LINE__, #__VA_ARGS__);                        \
-        DOCTEST_WRAP_IN_TRY(                                                                       \
-                _DOCTEST_RB.binary_assert<doctest::detail::binaryAssertComparison::comp>(          \
-                        __VA_ARGS__))                                                              \
-        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                 \
-    } while((void)0, 0)
-
-#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                     \
-    do {                                                                                           \
-        doctest::detail::ResultBuilder _DOCTEST_RB(doctest::assertType::assert_type, __FILE__,     \
-                                                   __LINE__, #__VA_ARGS__);                        \
-        DOCTEST_WRAP_IN_TRY(_DOCTEST_RB.unary_assert(__VA_ARGS__))                                 \
-        DOCTEST_ASSERT_LOG_AND_REACT(_DOCTEST_RB);                                                 \
-    } while((void)0, 0)
-
-#else // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
-
-#define DOCTEST_BINARY_ASSERT(assert_type, comparison, ...)                                        \
-    doctest::detail::binary_assert<doctest::detail::binaryAssertComparison::comparison>(           \
-            doctest::assertType::assert_type, __FILE__, __LINE__, #__VA_ARGS__, __VA_ARGS__)
-
-#define DOCTEST_UNARY_ASSERT(assert_type, ...)                                                     \
-    doctest::detail::unary_assert(doctest::assertType::assert_type, __FILE__, __LINE__,            \
-                                  #__VA_ARGS__, __VA_ARGS__)
-
-#endif // DOCTEST_CONFIG_SUPER_FAST_ASSERTS
 
 #define DOCTEST_WARN_EQ(...) DOCTEST_BINARY_ASSERT(DT_WARN_EQ, eq, __VA_ARGS__)
 #define DOCTEST_CHECK_EQ(...) DOCTEST_BINARY_ASSERT(DT_CHECK_EQ, eq, __VA_ARGS__)
@@ -2194,63 +2436,350 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 #define DOCTEST_CHECK_UNARY_FALSE(...) DOCTEST_UNARY_ASSERT(DT_CHECK_UNARY_FALSE, __VA_ARGS__)
 #define DOCTEST_REQUIRE_UNARY_FALSE(...) DOCTEST_UNARY_ASSERT(DT_REQUIRE_UNARY_FALSE, __VA_ARGS__)
 
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+
+#define DOCTEST_ASSERT_THROWS_AS(expr, assert_type, message, ...)                                  \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
+        if(!doctest::getContextOptions()->no_throw) {                                              \
+            doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,  \
+                                                       __LINE__, #expr, #__VA_ARGS__, message);    \
+            try {                                                                                  \
+                DOCTEST_CAST_TO_VOID(expr)                                                         \
+            } catch(const typename doctest::detail::types::remove_const<                           \
+                    typename doctest::detail::types::remove_reference<__VA_ARGS__>::type>::type&) {\
+                DOCTEST_RB.translateException();                                                   \
+                DOCTEST_RB.m_threw_as = true;                                                      \
+            } catch(...) { DOCTEST_RB.translateException(); }                                      \
+            DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                           \
+        } else { /* NOLINT(*-else-after-return) */                                                 \
+            DOCTEST_FUNC_SCOPE_RET(false);                                                         \
+        }                                                                                          \
+    } DOCTEST_FUNC_SCOPE_END
+
+#define DOCTEST_ASSERT_THROWS_WITH(expr, expr_str, assert_type, ...)                               \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
+        if(!doctest::getContextOptions()->no_throw) {                                              \
+            doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,  \
+                                                       __LINE__, expr_str, "", __VA_ARGS__);       \
+            try {                                                                                  \
+                DOCTEST_CAST_TO_VOID(expr)                                                         \
+            } catch(...) { DOCTEST_RB.translateException(); }                                      \
+            DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                           \
+        } else { /* NOLINT(*-else-after-return) */                                                 \
+           DOCTEST_FUNC_SCOPE_RET(false);                                                          \
+        }                                                                                          \
+    } DOCTEST_FUNC_SCOPE_END
+
+#define DOCTEST_ASSERT_NOTHROW(assert_type, ...)                                                   \
+    DOCTEST_FUNC_SCOPE_BEGIN {                                                                     \
+        doctest::detail::ResultBuilder DOCTEST_RB(doctest::assertType::assert_type, __FILE__,      \
+                                                   __LINE__, #__VA_ARGS__);                        \
+        try {                                                                                      \
+            DOCTEST_CAST_TO_VOID(__VA_ARGS__)                                                      \
+        } catch(...) { DOCTEST_RB.translateException(); }                                          \
+        DOCTEST_ASSERT_LOG_REACT_RETURN(DOCTEST_RB);                                               \
+    } DOCTEST_FUNC_SCOPE_END
+
+// clang-format off
+#define DOCTEST_WARN_THROWS(...) DOCTEST_ASSERT_THROWS_WITH((__VA_ARGS__), #__VA_ARGS__, DT_WARN_THROWS, "")
+#define DOCTEST_CHECK_THROWS(...) DOCTEST_ASSERT_THROWS_WITH((__VA_ARGS__), #__VA_ARGS__, DT_CHECK_THROWS, "")
+#define DOCTEST_REQUIRE_THROWS(...) DOCTEST_ASSERT_THROWS_WITH((__VA_ARGS__), #__VA_ARGS__, DT_REQUIRE_THROWS, "")
+
+#define DOCTEST_WARN_THROWS_AS(expr, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_WARN_THROWS_AS, "", __VA_ARGS__)
+#define DOCTEST_CHECK_THROWS_AS(expr, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_CHECK_THROWS_AS, "", __VA_ARGS__)
+#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_REQUIRE_THROWS_AS, "", __VA_ARGS__)
+
+#define DOCTEST_WARN_THROWS_WITH(expr, ...) DOCTEST_ASSERT_THROWS_WITH(expr, #expr, DT_WARN_THROWS_WITH, __VA_ARGS__)
+#define DOCTEST_CHECK_THROWS_WITH(expr, ...) DOCTEST_ASSERT_THROWS_WITH(expr, #expr, DT_CHECK_THROWS_WITH, __VA_ARGS__)
+#define DOCTEST_REQUIRE_THROWS_WITH(expr, ...) DOCTEST_ASSERT_THROWS_WITH(expr, #expr, DT_REQUIRE_THROWS_WITH, __VA_ARGS__)
+
+#define DOCTEST_WARN_THROWS_WITH_AS(expr, message, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_WARN_THROWS_WITH_AS, message, __VA_ARGS__)
+#define DOCTEST_CHECK_THROWS_WITH_AS(expr, message, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_CHECK_THROWS_WITH_AS, message, __VA_ARGS__)
+#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, message, ...) DOCTEST_ASSERT_THROWS_AS(expr, DT_REQUIRE_THROWS_WITH_AS, message, __VA_ARGS__)
+
+#define DOCTEST_WARN_NOTHROW(...) DOCTEST_ASSERT_NOTHROW(DT_WARN_NOTHROW, __VA_ARGS__)
+#define DOCTEST_CHECK_NOTHROW(...) DOCTEST_ASSERT_NOTHROW(DT_CHECK_NOTHROW, __VA_ARGS__)
+#define DOCTEST_REQUIRE_NOTHROW(...) DOCTEST_ASSERT_NOTHROW(DT_REQUIRE_NOTHROW, __VA_ARGS__)
+
+#define DOCTEST_WARN_THROWS_MESSAGE(expr, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_WARN_THROWS(expr); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_THROWS_MESSAGE(expr, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_CHECK_THROWS(expr); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_REQUIRE_THROWS(expr); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_WARN_THROWS_AS(expr, ex); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_CHECK_THROWS_AS(expr, ex); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_REQUIRE_THROWS_AS(expr, ex); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_WARN_THROWS_WITH(expr, with); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_CHECK_THROWS_WITH(expr, with); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_REQUIRE_THROWS_WITH(expr, with); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_WARN_THROWS_WITH_AS(expr, with, ex); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ex); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ex); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_WARN_NOTHROW(expr); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_CHECK_NOTHROW(expr); } DOCTEST_FUNC_SCOPE_END
+#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, ...) DOCTEST_FUNC_SCOPE_BEGIN { DOCTEST_INFO(__VA_ARGS__); DOCTEST_REQUIRE_NOTHROW(expr); } DOCTEST_FUNC_SCOPE_END
+// clang-format on
+
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+// =================================================================================================
+// == WHAT FOLLOWS IS VERSIONS OF THE MACROS THAT DO NOT DO ANY REGISTERING!                      ==
+// == THIS CAN BE ENABLED BY DEFINING DOCTEST_CONFIG_DISABLE GLOBALLY!                            ==
+// =================================================================================================
+#else // DOCTEST_CONFIG_DISABLE
+
+#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, name)                                           \
+    namespace /* NOLINT */ {                                                                       \
+        template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                           \
+        struct der : public base                                                                   \
+        { void f(); };                                                                             \
+    }                                                                                              \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
+    inline void der<DOCTEST_UNUSED_TEMPLATE_TYPE>::f()
+
+#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, name)                                              \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
+    static inline void f()
+
+// for registering tests
+#define DOCTEST_TEST_CASE(name)                                                                    \
+    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
+
+// for registering tests in classes
+#define DOCTEST_TEST_CASE_CLASS(name)                                                              \
+    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
+
+// for registering tests with a fixture
+#define DOCTEST_TEST_CASE_FIXTURE(x, name)                                                         \
+    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(DOCTEST_ANON_CLASS_), x,                           \
+                              DOCTEST_ANONYMOUS(DOCTEST_ANON_FUNC_), name)
+
+// for converting types to strings without the <typeinfo> header and demangling
+#define DOCTEST_TYPE_TO_STRING_AS(str, ...) static_assert(true, "")
+#define DOCTEST_TYPE_TO_STRING(...) static_assert(true, "")
+
+// for typed tests
+#define DOCTEST_TEST_CASE_TEMPLATE(name, type, ...)                                                \
+    template <typename type>                                                                       \
+    inline void DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_)()
+
+#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(name, type, id)                                          \
+    template <typename type>                                                                       \
+    inline void DOCTEST_ANONYMOUS(DOCTEST_ANON_TMP_)()
+
+#define DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, ...) static_assert(true, "")
+#define DOCTEST_TEST_CASE_TEMPLATE_APPLY(id, ...) static_assert(true, "")
+
+// for subcases
+#define DOCTEST_SUBCASE(name)
+
+// for a testsuite block
+#define DOCTEST_TEST_SUITE(name) namespace // NOLINT
+
+// for starting a testsuite block
+#define DOCTEST_TEST_SUITE_BEGIN(name) static_assert(true, "")
+
+// for ending a testsuite block
+#define DOCTEST_TEST_SUITE_END using DOCTEST_ANONYMOUS(DOCTEST_ANON_FOR_SEMICOLON_) = int
+
+#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                           \
+    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
+    static inline doctest::String DOCTEST_ANONYMOUS(DOCTEST_ANON_TRANSLATOR_)(signature)
+
+#define DOCTEST_REGISTER_REPORTER(name, priority, reporter)
+#define DOCTEST_REGISTER_LISTENER(name, priority, reporter)
+
+#define DOCTEST_INFO(...) (static_cast<void>(0))
+#define DOCTEST_CAPTURE(x) (static_cast<void>(0))
+#define DOCTEST_ADD_MESSAGE_AT(file, line, ...) (static_cast<void>(0))
+#define DOCTEST_ADD_FAIL_CHECK_AT(file, line, ...) (static_cast<void>(0))
+#define DOCTEST_ADD_FAIL_AT(file, line, ...) (static_cast<void>(0))
+#define DOCTEST_MESSAGE(...) (static_cast<void>(0))
+#define DOCTEST_FAIL_CHECK(...) (static_cast<void>(0))
+#define DOCTEST_FAIL(...) (static_cast<void>(0))
+
+#if defined(DOCTEST_CONFIG_EVALUATE_ASSERTS_EVEN_WHEN_DISABLED)                                    \
+ && defined(DOCTEST_CONFIG_ASSERTS_RETURN_VALUES)
+
+#define DOCTEST_WARN(...) [&] { return __VA_ARGS__; }()
+#define DOCTEST_CHECK(...) [&] { return __VA_ARGS__; }()
+#define DOCTEST_REQUIRE(...) [&] { return __VA_ARGS__; }()
+#define DOCTEST_WARN_FALSE(...) [&] { return !(__VA_ARGS__); }()
+#define DOCTEST_CHECK_FALSE(...) [&] { return !(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_FALSE(...) [&] { return !(__VA_ARGS__); }()
+
+#define DOCTEST_WARN_MESSAGE(cond, ...) [&] { return cond; }()
+#define DOCTEST_CHECK_MESSAGE(cond, ...) [&] { return cond; }()
+#define DOCTEST_REQUIRE_MESSAGE(cond, ...) [&] { return cond; }()
+#define DOCTEST_WARN_FALSE_MESSAGE(cond, ...) [&] { return !(cond); }()
+#define DOCTEST_CHECK_FALSE_MESSAGE(cond, ...) [&] { return !(cond); }()
+#define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, ...) [&] { return !(cond); }()
+
+namespace doctest {
+namespace detail {
+#define DOCTEST_RELATIONAL_OP(name, op)                                                            \
+    template <typename L, typename R>                                                              \
+    bool name(const DOCTEST_REF_WRAP(L) lhs, const DOCTEST_REF_WRAP(R) rhs) { return lhs op rhs; }
+
+    DOCTEST_RELATIONAL_OP(eq, ==)
+    DOCTEST_RELATIONAL_OP(ne, !=)
+    DOCTEST_RELATIONAL_OP(lt, <)
+    DOCTEST_RELATIONAL_OP(gt, >)
+    DOCTEST_RELATIONAL_OP(le, <=)
+    DOCTEST_RELATIONAL_OP(ge, >=)
+} // namespace detail
+} // namespace doctest
+
+#define DOCTEST_WARN_EQ(...) [&] { return doctest::detail::eq(__VA_ARGS__); }()
+#define DOCTEST_CHECK_EQ(...) [&] { return doctest::detail::eq(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_EQ(...) [&] { return doctest::detail::eq(__VA_ARGS__); }()
+#define DOCTEST_WARN_NE(...) [&] { return doctest::detail::ne(__VA_ARGS__); }()
+#define DOCTEST_CHECK_NE(...) [&] { return doctest::detail::ne(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_NE(...) [&] { return doctest::detail::ne(__VA_ARGS__); }()
+#define DOCTEST_WARN_LT(...) [&] { return doctest::detail::lt(__VA_ARGS__); }()
+#define DOCTEST_CHECK_LT(...) [&] { return doctest::detail::lt(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_LT(...) [&] { return doctest::detail::lt(__VA_ARGS__); }()
+#define DOCTEST_WARN_GT(...) [&] { return doctest::detail::gt(__VA_ARGS__); }()
+#define DOCTEST_CHECK_GT(...) [&] { return doctest::detail::gt(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_GT(...) [&] { return doctest::detail::gt(__VA_ARGS__); }()
+#define DOCTEST_WARN_LE(...) [&] { return doctest::detail::le(__VA_ARGS__); }()
+#define DOCTEST_CHECK_LE(...) [&] { return doctest::detail::le(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_LE(...) [&] { return doctest::detail::le(__VA_ARGS__); }()
+#define DOCTEST_WARN_GE(...) [&] { return doctest::detail::ge(__VA_ARGS__); }()
+#define DOCTEST_CHECK_GE(...) [&] { return doctest::detail::ge(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_GE(...) [&] { return doctest::detail::ge(__VA_ARGS__); }()
+#define DOCTEST_WARN_UNARY(...) [&] { return __VA_ARGS__; }()
+#define DOCTEST_CHECK_UNARY(...) [&] { return __VA_ARGS__; }()
+#define DOCTEST_REQUIRE_UNARY(...) [&] { return __VA_ARGS__; }()
+#define DOCTEST_WARN_UNARY_FALSE(...) [&] { return !(__VA_ARGS__); }()
+#define DOCTEST_CHECK_UNARY_FALSE(...) [&] { return !(__VA_ARGS__); }()
+#define DOCTEST_REQUIRE_UNARY_FALSE(...) [&] { return !(__VA_ARGS__); }()
+
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+
+#define DOCTEST_WARN_THROWS_WITH(expr, with, ...) [] { static_assert(false, "Exception translation is not available when doctest is disabled."); return false; }()
+#define DOCTEST_CHECK_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_REQUIRE_THROWS_WITH(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_WARN_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+
+#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH(,,)
+
+#define DOCTEST_WARN_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
+#define DOCTEST_CHECK_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
+#define DOCTEST_REQUIRE_THROWS(...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
+#define DOCTEST_WARN_THROWS_AS(expr, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
+#define DOCTEST_CHECK_THROWS_AS(expr, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
+#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
+#define DOCTEST_WARN_NOTHROW(...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+#define DOCTEST_CHECK_NOTHROW(...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+#define DOCTEST_REQUIRE_NOTHROW(...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+
+#define DOCTEST_WARN_THROWS_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
+#define DOCTEST_CHECK_THROWS_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
+#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return false; } catch (...) { return true; } }()
+#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
+#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
+#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...) [&] { try { expr; } catch (__VA_ARGS__) { return true; } catch (...) { } return false; }()
+#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, ...) [&] { try { __VA_ARGS__; return true; } catch (...) { return false; } }()
+
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+#else // DOCTEST_CONFIG_EVALUATE_ASSERTS_EVEN_WHEN_DISABLED
+
+#define DOCTEST_WARN(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_FALSE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_FALSE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_FALSE(...) DOCTEST_FUNC_EMPTY
+
+#define DOCTEST_WARN_MESSAGE(cond, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_MESSAGE(cond, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_MESSAGE(cond, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_FALSE_MESSAGE(cond, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_FALSE_MESSAGE(cond, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, ...) DOCTEST_FUNC_EMPTY
+
+#define DOCTEST_WARN_EQ(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_EQ(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_EQ(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_NE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_NE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_NE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_GT(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_GT(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_GT(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_LT(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_LT(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_LT(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_GE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_GE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_GE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_LE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_LE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_LE(...) DOCTEST_FUNC_EMPTY
+
+#define DOCTEST_WARN_UNARY(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_UNARY(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_UNARY(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_UNARY_FALSE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_UNARY_FALSE(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_UNARY_FALSE(...) DOCTEST_FUNC_EMPTY
+
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+
+#define DOCTEST_WARN_THROWS(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_THROWS_AS(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_AS(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_THROWS_WITH(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_WITH(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_WITH(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_THROWS_WITH_AS(expr, with, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_NOTHROW(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_NOTHROW(...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_NOTHROW(...) DOCTEST_FUNC_EMPTY
+
+#define DOCTEST_WARN_THROWS_MESSAGE(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_MESSAGE(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, ...) DOCTEST_FUNC_EMPTY
+#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, ...) DOCTEST_FUNC_EMPTY
+
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+
+#endif // DOCTEST_CONFIG_EVALUATE_ASSERTS_EVEN_WHEN_DISABLED
+
+#endif // DOCTEST_CONFIG_DISABLE
+
 #ifdef DOCTEST_CONFIG_NO_EXCEPTIONS
 
-#undef DOCTEST_WARN_THROWS
-#undef DOCTEST_CHECK_THROWS
-#undef DOCTEST_REQUIRE_THROWS
-#undef DOCTEST_WARN_THROWS_AS
-#undef DOCTEST_CHECK_THROWS_AS
-#undef DOCTEST_REQUIRE_THROWS_AS
-#undef DOCTEST_WARN_THROWS_WITH
-#undef DOCTEST_CHECK_THROWS_WITH
-#undef DOCTEST_REQUIRE_THROWS_WITH
-#undef DOCTEST_WARN_NOTHROW
-#undef DOCTEST_CHECK_NOTHROW
-#undef DOCTEST_REQUIRE_NOTHROW
-
-#undef DOCTEST_WARN_THROWS_MESSAGE
-#undef DOCTEST_CHECK_THROWS_MESSAGE
-#undef DOCTEST_REQUIRE_THROWS_MESSAGE
-#undef DOCTEST_WARN_THROWS_AS_MESSAGE
-#undef DOCTEST_CHECK_THROWS_AS_MESSAGE
-#undef DOCTEST_REQUIRE_THROWS_AS_MESSAGE
-#undef DOCTEST_WARN_THROWS_WITH_MESSAGE
-#undef DOCTEST_CHECK_THROWS_WITH_MESSAGE
-#undef DOCTEST_REQUIRE_THROWS_WITH_MESSAGE
-#undef DOCTEST_WARN_NOTHROW_MESSAGE
-#undef DOCTEST_CHECK_NOTHROW_MESSAGE
-#undef DOCTEST_REQUIRE_NOTHROW_MESSAGE
-
 #ifdef DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
-
-#define DOCTEST_WARN_THROWS(expr) ((void)0)
-#define DOCTEST_CHECK_THROWS(expr) ((void)0)
-#define DOCTEST_REQUIRE_THROWS(expr) ((void)0)
-#define DOCTEST_WARN_THROWS_AS(expr, ...) ((void)0)
-#define DOCTEST_CHECK_THROWS_AS(expr, ...) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) ((void)0)
-#define DOCTEST_WARN_THROWS_WITH(expr, ...) ((void)0)
-#define DOCTEST_CHECK_THROWS_WITH(expr, ...) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_WITH(expr, ...) ((void)0)
-#define DOCTEST_WARN_NOTHROW(expr) ((void)0)
-#define DOCTEST_CHECK_NOTHROW(expr) ((void)0)
-#define DOCTEST_REQUIRE_NOTHROW(expr) ((void)0)
-
-#define DOCTEST_WARN_THROWS_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_CHECK_THROWS_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, msg) ((void)0)
-
+#define DOCTEST_EXCEPTION_EMPTY_FUNC DOCTEST_FUNC_EMPTY
 #else // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
+#define DOCTEST_EXCEPTION_EMPTY_FUNC [] { static_assert(false, "Exceptions are disabled! " \
+    "Use DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS if you want to compile with exceptions disabled."); return false; }()
 
 #undef DOCTEST_REQUIRE
 #undef DOCTEST_REQUIRE_FALSE
@@ -2265,156 +2794,54 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 #undef DOCTEST_REQUIRE_UNARY
 #undef DOCTEST_REQUIRE_UNARY_FALSE
 
+#define DOCTEST_REQUIRE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_FALSE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_MESSAGE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_FALSE_MESSAGE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_EQ DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_NE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_GT DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_LT DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_GE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_LE DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_UNARY DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_UNARY_FALSE DOCTEST_EXCEPTION_EMPTY_FUNC
+
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS
 
+#define DOCTEST_WARN_THROWS(...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS(...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS(...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_THROWS_AS(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_AS(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_THROWS_WITH(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_WITH(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_WITH(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_THROWS_WITH_AS(expr, with, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_WITH_AS(expr, with, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_NOTHROW(...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_NOTHROW(...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_NOTHROW(...) DOCTEST_EXCEPTION_EMPTY_FUNC
+
+#define DOCTEST_WARN_THROWS_MESSAGE(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_MESSAGE(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, ...) DOCTEST_EXCEPTION_EMPTY_FUNC
+
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-
-// =================================================================================================
-// == WHAT FOLLOWS IS VERSIONS OF THE MACROS THAT DO NOT DO ANY REGISTERING!                      ==
-// == THIS CAN BE ENABLED BY DEFINING DOCTEST_CONFIG_DISABLE GLOBALLY!                            ==
-// =================================================================================================
-#else // DOCTEST_CONFIG_DISABLE
-
-#define DOCTEST_IMPLEMENT_FIXTURE(der, base, func, name)                                           \
-    namespace {                                                                                    \
-        template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                           \
-        struct der : public base                                                                   \
-        { void f(); };                                                                             \
-    }                                                                                              \
-    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
-    inline void der<DOCTEST_UNUSED_TEMPLATE_TYPE>::f()
-
-#define DOCTEST_CREATE_AND_REGISTER_FUNCTION(f, name)                                              \
-    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
-    static inline void f()
-
-// for registering tests
-#define DOCTEST_TEST_CASE(name)                                                                    \
-    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), name)
-
-// for registering tests in classes
-#define DOCTEST_TEST_CASE_CLASS(name)                                                              \
-    DOCTEST_CREATE_AND_REGISTER_FUNCTION(DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), name)
-
-// for registering tests with a fixture
-#define DOCTEST_TEST_CASE_FIXTURE(x, name)                                                         \
-    DOCTEST_IMPLEMENT_FIXTURE(DOCTEST_ANONYMOUS(_DOCTEST_ANON_CLASS_), x,                          \
-                              DOCTEST_ANONYMOUS(_DOCTEST_ANON_FUNC_), name)
-
-// for converting types to strings without the <typeinfo> header and demangling
-#define DOCTEST_TYPE_TO_STRING(...) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-#define DOCTEST_TYPE_TO_STRING_IMPL(...)
-
-// for typed tests
-#define DOCTEST_TEST_CASE_TEMPLATE(name, type, ...)                                                \
-    template <typename type>                                                                       \
-    inline void DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_)()
-
-#define DOCTEST_TEST_CASE_TEMPLATE_DEFINE(name, type, id)                                          \
-    template <typename type>                                                                       \
-    inline void DOCTEST_ANONYMOUS(_DOCTEST_ANON_TMP_)()
-
-#define DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, ...)                                                 \
-    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-
-#define DOCTEST_TEST_CASE_TEMPLATE_APPLY(id, ...)                                                  \
-    typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-
-// for subcases
-#define DOCTEST_SUBCASE(name)
-
-// for a testsuite block
-#define DOCTEST_TEST_SUITE(name) namespace
-
-// for starting a testsuite block
-#define DOCTEST_TEST_SUITE_BEGIN(name) typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-
-// for ending a testsuite block
-#define DOCTEST_TEST_SUITE_END typedef int DOCTEST_ANONYMOUS(_DOCTEST_ANON_FOR_SEMICOLON_)
-
-#define DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)                                           \
-    template <typename DOCTEST_UNUSED_TEMPLATE_TYPE>                                               \
-    static inline doctest::String DOCTEST_ANONYMOUS(_DOCTEST_ANON_TRANSLATOR_)(signature)
-
-#define DOCTEST_REGISTER_REPORTER(name, priority, reporter)
-#define DOCTEST_REGISTER_LISTENER(name, priority, reporter)
-
-#define DOCTEST_INFO(x) ((void)0)
-#define DOCTEST_CAPTURE(x) ((void)0)
-#define DOCTEST_ADD_MESSAGE_AT(file, line, x) ((void)0)
-#define DOCTEST_ADD_FAIL_CHECK_AT(file, line, x) ((void)0)
-#define DOCTEST_ADD_FAIL_AT(file, line, x) ((void)0)
-#define DOCTEST_MESSAGE(x) ((void)0)
-#define DOCTEST_FAIL_CHECK(x) ((void)0)
-#define DOCTEST_FAIL(x) ((void)0)
-
-#define DOCTEST_WARN(...) ((void)0)
-#define DOCTEST_CHECK(...) ((void)0)
-#define DOCTEST_REQUIRE(...) ((void)0)
-#define DOCTEST_WARN_FALSE(...) ((void)0)
-#define DOCTEST_CHECK_FALSE(...) ((void)0)
-#define DOCTEST_REQUIRE_FALSE(...) ((void)0)
-
-#define DOCTEST_WARN_MESSAGE(cond, msg) ((void)0)
-#define DOCTEST_CHECK_MESSAGE(cond, msg) ((void)0)
-#define DOCTEST_REQUIRE_MESSAGE(cond, msg) ((void)0)
-#define DOCTEST_WARN_FALSE_MESSAGE(cond, msg) ((void)0)
-#define DOCTEST_CHECK_FALSE_MESSAGE(cond, msg) ((void)0)
-#define DOCTEST_REQUIRE_FALSE_MESSAGE(cond, msg) ((void)0)
-
-#define DOCTEST_WARN_THROWS(expr) ((void)0)
-#define DOCTEST_CHECK_THROWS(expr) ((void)0)
-#define DOCTEST_REQUIRE_THROWS(expr) ((void)0)
-#define DOCTEST_WARN_THROWS_AS(expr, ...) ((void)0)
-#define DOCTEST_CHECK_THROWS_AS(expr, ...) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_AS(expr, ...) ((void)0)
-#define DOCTEST_WARN_THROWS_WITH(expr, ...) ((void)0)
-#define DOCTEST_CHECK_THROWS_WITH(expr, ...) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_WITH(expr, ...) ((void)0)
-#define DOCTEST_WARN_NOTHROW(expr) ((void)0)
-#define DOCTEST_CHECK_NOTHROW(expr) ((void)0)
-#define DOCTEST_REQUIRE_NOTHROW(expr) ((void)0)
-
-#define DOCTEST_WARN_THROWS_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_CHECK_THROWS_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, ex, msg) ((void)0)
-#define DOCTEST_WARN_NOTHROW_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_CHECK_NOTHROW_MESSAGE(expr, msg) ((void)0)
-#define DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, msg) ((void)0)
-
-#define DOCTEST_WARN_EQ(...) ((void)0)
-#define DOCTEST_CHECK_EQ(...) ((void)0)
-#define DOCTEST_REQUIRE_EQ(...) ((void)0)
-#define DOCTEST_WARN_NE(...) ((void)0)
-#define DOCTEST_CHECK_NE(...) ((void)0)
-#define DOCTEST_REQUIRE_NE(...) ((void)0)
-#define DOCTEST_WARN_GT(...) ((void)0)
-#define DOCTEST_CHECK_GT(...) ((void)0)
-#define DOCTEST_REQUIRE_GT(...) ((void)0)
-#define DOCTEST_WARN_LT(...) ((void)0)
-#define DOCTEST_CHECK_LT(...) ((void)0)
-#define DOCTEST_REQUIRE_LT(...) ((void)0)
-#define DOCTEST_WARN_GE(...) ((void)0)
-#define DOCTEST_CHECK_GE(...) ((void)0)
-#define DOCTEST_REQUIRE_GE(...) ((void)0)
-#define DOCTEST_WARN_LE(...) ((void)0)
-#define DOCTEST_CHECK_LE(...) ((void)0)
-#define DOCTEST_REQUIRE_LE(...) ((void)0)
-
-#define DOCTEST_WARN_UNARY(...) ((void)0)
-#define DOCTEST_CHECK_UNARY(...) ((void)0)
-#define DOCTEST_REQUIRE_UNARY(...) ((void)0)
-#define DOCTEST_WARN_UNARY_FALSE(...) ((void)0)
-#define DOCTEST_CHECK_UNARY_FALSE(...) ((void)0)
-#define DOCTEST_REQUIRE_UNARY_FALSE(...) ((void)0)
-
-#endif // DOCTEST_CONFIG_DISABLE
 
 // clang-format off
 // KEPT FOR BACKWARDS COMPATIBILITY - FORWARDING TO THE RIGHT MACROS
@@ -2444,7 +2871,7 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 #define DOCTEST_FAST_CHECK_UNARY_FALSE   DOCTEST_CHECK_UNARY_FALSE
 #define DOCTEST_FAST_REQUIRE_UNARY_FALSE DOCTEST_REQUIRE_UNARY_FALSE
 
-#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE DOCTEST_TEST_CASE_TEMPLATE_INVOKE
+#define DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, ...) DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id,__VA_ARGS__)
 // clang-format on
 
 // BDD style macros
@@ -2462,169 +2889,156 @@ int registerReporter(const char* name, int priority, bool isReporter) {
 // clang-format on
 
 // == SHORT VERSIONS OF THE MACROS
-#if !defined(DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES)
+#ifndef DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES
 
-#define TEST_CASE DOCTEST_TEST_CASE
-#define TEST_CASE_CLASS DOCTEST_TEST_CASE_CLASS
-#define TEST_CASE_FIXTURE DOCTEST_TEST_CASE_FIXTURE
-#define TYPE_TO_STRING DOCTEST_TYPE_TO_STRING
-#define TEST_CASE_TEMPLATE DOCTEST_TEST_CASE_TEMPLATE
-#define TEST_CASE_TEMPLATE_DEFINE DOCTEST_TEST_CASE_TEMPLATE_DEFINE
-#define TEST_CASE_TEMPLATE_INVOKE DOCTEST_TEST_CASE_TEMPLATE_INVOKE
-#define TEST_CASE_TEMPLATE_APPLY DOCTEST_TEST_CASE_TEMPLATE_APPLY
-#define SUBCASE DOCTEST_SUBCASE
-#define TEST_SUITE DOCTEST_TEST_SUITE
-#define TEST_SUITE_BEGIN DOCTEST_TEST_SUITE_BEGIN
+#define TEST_CASE(name) DOCTEST_TEST_CASE(name)
+#define TEST_CASE_CLASS(name) DOCTEST_TEST_CASE_CLASS(name)
+#define TEST_CASE_FIXTURE(x, name) DOCTEST_TEST_CASE_FIXTURE(x, name)
+#define TYPE_TO_STRING_AS(str, ...) DOCTEST_TYPE_TO_STRING_AS(str, __VA_ARGS__)
+#define TYPE_TO_STRING(...) DOCTEST_TYPE_TO_STRING(__VA_ARGS__)
+#define TEST_CASE_TEMPLATE(name, T, ...) DOCTEST_TEST_CASE_TEMPLATE(name, T, __VA_ARGS__)
+#define TEST_CASE_TEMPLATE_DEFINE(name, T, id) DOCTEST_TEST_CASE_TEMPLATE_DEFINE(name, T, id)
+#define TEST_CASE_TEMPLATE_INVOKE(id, ...) DOCTEST_TEST_CASE_TEMPLATE_INVOKE(id, __VA_ARGS__)
+#define TEST_CASE_TEMPLATE_APPLY(id, ...) DOCTEST_TEST_CASE_TEMPLATE_APPLY(id, __VA_ARGS__)
+#define SUBCASE(name) DOCTEST_SUBCASE(name)
+#define TEST_SUITE(decorators) DOCTEST_TEST_SUITE(decorators)
+#define TEST_SUITE_BEGIN(name) DOCTEST_TEST_SUITE_BEGIN(name)
 #define TEST_SUITE_END DOCTEST_TEST_SUITE_END
-#define REGISTER_EXCEPTION_TRANSLATOR DOCTEST_REGISTER_EXCEPTION_TRANSLATOR
-#define REGISTER_REPORTER DOCTEST_REGISTER_REPORTER
-#define REGISTER_LISTENER DOCTEST_REGISTER_LISTENER
-#define INFO DOCTEST_INFO
-#define CAPTURE DOCTEST_CAPTURE
-#define ADD_MESSAGE_AT DOCTEST_ADD_MESSAGE_AT
-#define ADD_FAIL_CHECK_AT DOCTEST_ADD_FAIL_CHECK_AT
-#define ADD_FAIL_AT DOCTEST_ADD_FAIL_AT
-#define MESSAGE DOCTEST_MESSAGE
-#define FAIL_CHECK DOCTEST_FAIL_CHECK
-#define FAIL DOCTEST_FAIL
-#define TO_LVALUE DOCTEST_TO_LVALUE
+#define REGISTER_EXCEPTION_TRANSLATOR(signature) DOCTEST_REGISTER_EXCEPTION_TRANSLATOR(signature)
+#define REGISTER_REPORTER(name, priority, reporter) DOCTEST_REGISTER_REPORTER(name, priority, reporter)
+#define REGISTER_LISTENER(name, priority, reporter) DOCTEST_REGISTER_LISTENER(name, priority, reporter)
+#define INFO(...) DOCTEST_INFO(__VA_ARGS__)
+#define CAPTURE(x) DOCTEST_CAPTURE(x)
+#define ADD_MESSAGE_AT(file, line, ...) DOCTEST_ADD_MESSAGE_AT(file, line, __VA_ARGS__)
+#define ADD_FAIL_CHECK_AT(file, line, ...) DOCTEST_ADD_FAIL_CHECK_AT(file, line, __VA_ARGS__)
+#define ADD_FAIL_AT(file, line, ...) DOCTEST_ADD_FAIL_AT(file, line, __VA_ARGS__)
+#define MESSAGE(...) DOCTEST_MESSAGE(__VA_ARGS__)
+#define FAIL_CHECK(...) DOCTEST_FAIL_CHECK(__VA_ARGS__)
+#define FAIL(...) DOCTEST_FAIL(__VA_ARGS__)
+#define TO_LVALUE(...) DOCTEST_TO_LVALUE(__VA_ARGS__)
 
-#define WARN DOCTEST_WARN
-#define WARN_FALSE DOCTEST_WARN_FALSE
-#define WARN_THROWS DOCTEST_WARN_THROWS
-#define WARN_THROWS_AS DOCTEST_WARN_THROWS_AS
-#define WARN_THROWS_WITH DOCTEST_WARN_THROWS_WITH
-#define WARN_NOTHROW DOCTEST_WARN_NOTHROW
-#define CHECK DOCTEST_CHECK
-#define CHECK_FALSE DOCTEST_CHECK_FALSE
-#define CHECK_THROWS DOCTEST_CHECK_THROWS
-#define CHECK_THROWS_AS DOCTEST_CHECK_THROWS_AS
-#define CHECK_THROWS_WITH DOCTEST_CHECK_THROWS_WITH
-#define CHECK_NOTHROW DOCTEST_CHECK_NOTHROW
-#define REQUIRE DOCTEST_REQUIRE
-#define REQUIRE_FALSE DOCTEST_REQUIRE_FALSE
-#define REQUIRE_THROWS DOCTEST_REQUIRE_THROWS
-#define REQUIRE_THROWS_AS DOCTEST_REQUIRE_THROWS_AS
-#define REQUIRE_THROWS_WITH DOCTEST_REQUIRE_THROWS_WITH
-#define REQUIRE_NOTHROW DOCTEST_REQUIRE_NOTHROW
+#define WARN(...) DOCTEST_WARN(__VA_ARGS__)
+#define WARN_FALSE(...) DOCTEST_WARN_FALSE(__VA_ARGS__)
+#define WARN_THROWS(...) DOCTEST_WARN_THROWS(__VA_ARGS__)
+#define WARN_THROWS_AS(expr, ...) DOCTEST_WARN_THROWS_AS(expr, __VA_ARGS__)
+#define WARN_THROWS_WITH(expr, ...) DOCTEST_WARN_THROWS_WITH(expr, __VA_ARGS__)
+#define WARN_THROWS_WITH_AS(expr, with, ...) DOCTEST_WARN_THROWS_WITH_AS(expr, with, __VA_ARGS__)
+#define WARN_NOTHROW(...) DOCTEST_WARN_NOTHROW(__VA_ARGS__)
+#define CHECK(...) DOCTEST_CHECK(__VA_ARGS__)
+#define CHECK_FALSE(...) DOCTEST_CHECK_FALSE(__VA_ARGS__)
+#define CHECK_THROWS(...) DOCTEST_CHECK_THROWS(__VA_ARGS__)
+#define CHECK_THROWS_AS(expr, ...) DOCTEST_CHECK_THROWS_AS(expr, __VA_ARGS__)
+#define CHECK_THROWS_WITH(expr, ...) DOCTEST_CHECK_THROWS_WITH(expr, __VA_ARGS__)
+#define CHECK_THROWS_WITH_AS(expr, with, ...) DOCTEST_CHECK_THROWS_WITH_AS(expr, with, __VA_ARGS__)
+#define CHECK_NOTHROW(...) DOCTEST_CHECK_NOTHROW(__VA_ARGS__)
+#define REQUIRE(...) DOCTEST_REQUIRE(__VA_ARGS__)
+#define REQUIRE_FALSE(...) DOCTEST_REQUIRE_FALSE(__VA_ARGS__)
+#define REQUIRE_THROWS(...) DOCTEST_REQUIRE_THROWS(__VA_ARGS__)
+#define REQUIRE_THROWS_AS(expr, ...) DOCTEST_REQUIRE_THROWS_AS(expr, __VA_ARGS__)
+#define REQUIRE_THROWS_WITH(expr, ...) DOCTEST_REQUIRE_THROWS_WITH(expr, __VA_ARGS__)
+#define REQUIRE_THROWS_WITH_AS(expr, with, ...) DOCTEST_REQUIRE_THROWS_WITH_AS(expr, with, __VA_ARGS__)
+#define REQUIRE_NOTHROW(...) DOCTEST_REQUIRE_NOTHROW(__VA_ARGS__)
 
-#define WARN_MESSAGE DOCTEST_WARN_MESSAGE
-#define WARN_FALSE_MESSAGE DOCTEST_WARN_FALSE_MESSAGE
-#define WARN_THROWS_MESSAGE DOCTEST_WARN_THROWS_MESSAGE
-#define WARN_THROWS_AS_MESSAGE DOCTEST_WARN_THROWS_AS_MESSAGE
-#define WARN_THROWS_WITH_MESSAGE DOCTEST_WARN_THROWS_WITH_MESSAGE
-#define WARN_NOTHROW_MESSAGE DOCTEST_WARN_NOTHROW_MESSAGE
-#define CHECK_MESSAGE DOCTEST_CHECK_MESSAGE
-#define CHECK_FALSE_MESSAGE DOCTEST_CHECK_FALSE_MESSAGE
-#define CHECK_THROWS_MESSAGE DOCTEST_CHECK_THROWS_MESSAGE
-#define CHECK_THROWS_AS_MESSAGE DOCTEST_CHECK_THROWS_AS_MESSAGE
-#define CHECK_THROWS_WITH_MESSAGE DOCTEST_CHECK_THROWS_WITH_MESSAGE
-#define CHECK_NOTHROW_MESSAGE DOCTEST_CHECK_NOTHROW_MESSAGE
-#define REQUIRE_MESSAGE DOCTEST_REQUIRE_MESSAGE
-#define REQUIRE_FALSE_MESSAGE DOCTEST_REQUIRE_FALSE_MESSAGE
-#define REQUIRE_THROWS_MESSAGE DOCTEST_REQUIRE_THROWS_MESSAGE
-#define REQUIRE_THROWS_AS_MESSAGE DOCTEST_REQUIRE_THROWS_AS_MESSAGE
-#define REQUIRE_THROWS_WITH_MESSAGE DOCTEST_REQUIRE_THROWS_WITH_MESSAGE
-#define REQUIRE_NOTHROW_MESSAGE DOCTEST_REQUIRE_NOTHROW_MESSAGE
+#define WARN_MESSAGE(cond, ...) DOCTEST_WARN_MESSAGE(cond, __VA_ARGS__)
+#define WARN_FALSE_MESSAGE(cond, ...) DOCTEST_WARN_FALSE_MESSAGE(cond, __VA_ARGS__)
+#define WARN_THROWS_MESSAGE(expr, ...) DOCTEST_WARN_THROWS_MESSAGE(expr, __VA_ARGS__)
+#define WARN_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_WARN_THROWS_AS_MESSAGE(expr, ex, __VA_ARGS__)
+#define WARN_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_WARN_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
+#define WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_WARN_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
+#define WARN_NOTHROW_MESSAGE(expr, ...) DOCTEST_WARN_NOTHROW_MESSAGE(expr, __VA_ARGS__)
+#define CHECK_MESSAGE(cond, ...) DOCTEST_CHECK_MESSAGE(cond, __VA_ARGS__)
+#define CHECK_FALSE_MESSAGE(cond, ...) DOCTEST_CHECK_FALSE_MESSAGE(cond, __VA_ARGS__)
+#define CHECK_THROWS_MESSAGE(expr, ...) DOCTEST_CHECK_THROWS_MESSAGE(expr, __VA_ARGS__)
+#define CHECK_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_CHECK_THROWS_AS_MESSAGE(expr, ex, __VA_ARGS__)
+#define CHECK_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_CHECK_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
+#define CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_CHECK_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
+#define CHECK_NOTHROW_MESSAGE(expr, ...) DOCTEST_CHECK_NOTHROW_MESSAGE(expr, __VA_ARGS__)
+#define REQUIRE_MESSAGE(cond, ...) DOCTEST_REQUIRE_MESSAGE(cond, __VA_ARGS__)
+#define REQUIRE_FALSE_MESSAGE(cond, ...) DOCTEST_REQUIRE_FALSE_MESSAGE(cond, __VA_ARGS__)
+#define REQUIRE_THROWS_MESSAGE(expr, ...) DOCTEST_REQUIRE_THROWS_MESSAGE(expr, __VA_ARGS__)
+#define REQUIRE_THROWS_AS_MESSAGE(expr, ex, ...) DOCTEST_REQUIRE_THROWS_AS_MESSAGE(expr, ex, __VA_ARGS__)
+#define REQUIRE_THROWS_WITH_MESSAGE(expr, with, ...) DOCTEST_REQUIRE_THROWS_WITH_MESSAGE(expr, with, __VA_ARGS__)
+#define REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, ...) DOCTEST_REQUIRE_THROWS_WITH_AS_MESSAGE(expr, with, ex, __VA_ARGS__)
+#define REQUIRE_NOTHROW_MESSAGE(expr, ...) DOCTEST_REQUIRE_NOTHROW_MESSAGE(expr, __VA_ARGS__)
 
-#define SCENARIO DOCTEST_SCENARIO
-#define SCENARIO_CLASS DOCTEST_SCENARIO_CLASS
-#define SCENARIO_TEMPLATE DOCTEST_SCENARIO_TEMPLATE
-#define SCENARIO_TEMPLATE_DEFINE DOCTEST_SCENARIO_TEMPLATE_DEFINE
-#define GIVEN DOCTEST_GIVEN
-#define WHEN DOCTEST_WHEN
-#define AND_WHEN DOCTEST_AND_WHEN
-#define THEN DOCTEST_THEN
-#define AND_THEN DOCTEST_AND_THEN
+#define SCENARIO(name) DOCTEST_SCENARIO(name)
+#define SCENARIO_CLASS(name) DOCTEST_SCENARIO_CLASS(name)
+#define SCENARIO_TEMPLATE(name, T, ...) DOCTEST_SCENARIO_TEMPLATE(name, T, __VA_ARGS__)
+#define SCENARIO_TEMPLATE_DEFINE(name, T, id) DOCTEST_SCENARIO_TEMPLATE_DEFINE(name, T, id)
+#define GIVEN(name) DOCTEST_GIVEN(name)
+#define WHEN(name) DOCTEST_WHEN(name)
+#define AND_WHEN(name) DOCTEST_AND_WHEN(name)
+#define THEN(name) DOCTEST_THEN(name)
+#define AND_THEN(name) DOCTEST_AND_THEN(name)
 
-#define WARN_EQ DOCTEST_WARN_EQ
-#define CHECK_EQ DOCTEST_CHECK_EQ
-#define REQUIRE_EQ DOCTEST_REQUIRE_EQ
-#define WARN_NE DOCTEST_WARN_NE
-#define CHECK_NE DOCTEST_CHECK_NE
-#define REQUIRE_NE DOCTEST_REQUIRE_NE
-#define WARN_GT DOCTEST_WARN_GT
-#define CHECK_GT DOCTEST_CHECK_GT
-#define REQUIRE_GT DOCTEST_REQUIRE_GT
-#define WARN_LT DOCTEST_WARN_LT
-#define CHECK_LT DOCTEST_CHECK_LT
-#define REQUIRE_LT DOCTEST_REQUIRE_LT
-#define WARN_GE DOCTEST_WARN_GE
-#define CHECK_GE DOCTEST_CHECK_GE
-#define REQUIRE_GE DOCTEST_REQUIRE_GE
-#define WARN_LE DOCTEST_WARN_LE
-#define CHECK_LE DOCTEST_CHECK_LE
-#define REQUIRE_LE DOCTEST_REQUIRE_LE
-#define WARN_UNARY DOCTEST_WARN_UNARY
-#define CHECK_UNARY DOCTEST_CHECK_UNARY
-#define REQUIRE_UNARY DOCTEST_REQUIRE_UNARY
-#define WARN_UNARY_FALSE DOCTEST_WARN_UNARY_FALSE
-#define CHECK_UNARY_FALSE DOCTEST_CHECK_UNARY_FALSE
-#define REQUIRE_UNARY_FALSE DOCTEST_REQUIRE_UNARY_FALSE
+#define WARN_EQ(...) DOCTEST_WARN_EQ(__VA_ARGS__)
+#define CHECK_EQ(...) DOCTEST_CHECK_EQ(__VA_ARGS__)
+#define REQUIRE_EQ(...) DOCTEST_REQUIRE_EQ(__VA_ARGS__)
+#define WARN_NE(...) DOCTEST_WARN_NE(__VA_ARGS__)
+#define CHECK_NE(...) DOCTEST_CHECK_NE(__VA_ARGS__)
+#define REQUIRE_NE(...) DOCTEST_REQUIRE_NE(__VA_ARGS__)
+#define WARN_GT(...) DOCTEST_WARN_GT(__VA_ARGS__)
+#define CHECK_GT(...) DOCTEST_CHECK_GT(__VA_ARGS__)
+#define REQUIRE_GT(...) DOCTEST_REQUIRE_GT(__VA_ARGS__)
+#define WARN_LT(...) DOCTEST_WARN_LT(__VA_ARGS__)
+#define CHECK_LT(...) DOCTEST_CHECK_LT(__VA_ARGS__)
+#define REQUIRE_LT(...) DOCTEST_REQUIRE_LT(__VA_ARGS__)
+#define WARN_GE(...) DOCTEST_WARN_GE(__VA_ARGS__)
+#define CHECK_GE(...) DOCTEST_CHECK_GE(__VA_ARGS__)
+#define REQUIRE_GE(...) DOCTEST_REQUIRE_GE(__VA_ARGS__)
+#define WARN_LE(...) DOCTEST_WARN_LE(__VA_ARGS__)
+#define CHECK_LE(...) DOCTEST_CHECK_LE(__VA_ARGS__)
+#define REQUIRE_LE(...) DOCTEST_REQUIRE_LE(__VA_ARGS__)
+#define WARN_UNARY(...) DOCTEST_WARN_UNARY(__VA_ARGS__)
+#define CHECK_UNARY(...) DOCTEST_CHECK_UNARY(__VA_ARGS__)
+#define REQUIRE_UNARY(...) DOCTEST_REQUIRE_UNARY(__VA_ARGS__)
+#define WARN_UNARY_FALSE(...) DOCTEST_WARN_UNARY_FALSE(__VA_ARGS__)
+#define CHECK_UNARY_FALSE(...) DOCTEST_CHECK_UNARY_FALSE(__VA_ARGS__)
+#define REQUIRE_UNARY_FALSE(...) DOCTEST_REQUIRE_UNARY_FALSE(__VA_ARGS__)
 
 // KEPT FOR BACKWARDS COMPATIBILITY
-#define FAST_WARN_EQ DOCTEST_FAST_WARN_EQ
-#define FAST_CHECK_EQ DOCTEST_FAST_CHECK_EQ
-#define FAST_REQUIRE_EQ DOCTEST_FAST_REQUIRE_EQ
-#define FAST_WARN_NE DOCTEST_FAST_WARN_NE
-#define FAST_CHECK_NE DOCTEST_FAST_CHECK_NE
-#define FAST_REQUIRE_NE DOCTEST_FAST_REQUIRE_NE
-#define FAST_WARN_GT DOCTEST_FAST_WARN_GT
-#define FAST_CHECK_GT DOCTEST_FAST_CHECK_GT
-#define FAST_REQUIRE_GT DOCTEST_FAST_REQUIRE_GT
-#define FAST_WARN_LT DOCTEST_FAST_WARN_LT
-#define FAST_CHECK_LT DOCTEST_FAST_CHECK_LT
-#define FAST_REQUIRE_LT DOCTEST_FAST_REQUIRE_LT
-#define FAST_WARN_GE DOCTEST_FAST_WARN_GE
-#define FAST_CHECK_GE DOCTEST_FAST_CHECK_GE
-#define FAST_REQUIRE_GE DOCTEST_FAST_REQUIRE_GE
-#define FAST_WARN_LE DOCTEST_FAST_WARN_LE
-#define FAST_CHECK_LE DOCTEST_FAST_CHECK_LE
-#define FAST_REQUIRE_LE DOCTEST_FAST_REQUIRE_LE
+#define FAST_WARN_EQ(...) DOCTEST_FAST_WARN_EQ(__VA_ARGS__)
+#define FAST_CHECK_EQ(...) DOCTEST_FAST_CHECK_EQ(__VA_ARGS__)
+#define FAST_REQUIRE_EQ(...) DOCTEST_FAST_REQUIRE_EQ(__VA_ARGS__)
+#define FAST_WARN_NE(...) DOCTEST_FAST_WARN_NE(__VA_ARGS__)
+#define FAST_CHECK_NE(...) DOCTEST_FAST_CHECK_NE(__VA_ARGS__)
+#define FAST_REQUIRE_NE(...) DOCTEST_FAST_REQUIRE_NE(__VA_ARGS__)
+#define FAST_WARN_GT(...) DOCTEST_FAST_WARN_GT(__VA_ARGS__)
+#define FAST_CHECK_GT(...) DOCTEST_FAST_CHECK_GT(__VA_ARGS__)
+#define FAST_REQUIRE_GT(...) DOCTEST_FAST_REQUIRE_GT(__VA_ARGS__)
+#define FAST_WARN_LT(...) DOCTEST_FAST_WARN_LT(__VA_ARGS__)
+#define FAST_CHECK_LT(...) DOCTEST_FAST_CHECK_LT(__VA_ARGS__)
+#define FAST_REQUIRE_LT(...) DOCTEST_FAST_REQUIRE_LT(__VA_ARGS__)
+#define FAST_WARN_GE(...) DOCTEST_FAST_WARN_GE(__VA_ARGS__)
+#define FAST_CHECK_GE(...) DOCTEST_FAST_CHECK_GE(__VA_ARGS__)
+#define FAST_REQUIRE_GE(...) DOCTEST_FAST_REQUIRE_GE(__VA_ARGS__)
+#define FAST_WARN_LE(...) DOCTEST_FAST_WARN_LE(__VA_ARGS__)
+#define FAST_CHECK_LE(...) DOCTEST_FAST_CHECK_LE(__VA_ARGS__)
+#define FAST_REQUIRE_LE(...) DOCTEST_FAST_REQUIRE_LE(__VA_ARGS__)
 
-#define FAST_WARN_UNARY DOCTEST_FAST_WARN_UNARY
-#define FAST_CHECK_UNARY DOCTEST_FAST_CHECK_UNARY
-#define FAST_REQUIRE_UNARY DOCTEST_FAST_REQUIRE_UNARY
-#define FAST_WARN_UNARY_FALSE DOCTEST_FAST_WARN_UNARY_FALSE
-#define FAST_CHECK_UNARY_FALSE DOCTEST_FAST_CHECK_UNARY_FALSE
-#define FAST_REQUIRE_UNARY_FALSE DOCTEST_FAST_REQUIRE_UNARY_FALSE
+#define FAST_WARN_UNARY(...) DOCTEST_FAST_WARN_UNARY(__VA_ARGS__)
+#define FAST_CHECK_UNARY(...) DOCTEST_FAST_CHECK_UNARY(__VA_ARGS__)
+#define FAST_REQUIRE_UNARY(...) DOCTEST_FAST_REQUIRE_UNARY(__VA_ARGS__)
+#define FAST_WARN_UNARY_FALSE(...) DOCTEST_FAST_WARN_UNARY_FALSE(__VA_ARGS__)
+#define FAST_CHECK_UNARY_FALSE(...) DOCTEST_FAST_CHECK_UNARY_FALSE(__VA_ARGS__)
+#define FAST_REQUIRE_UNARY_FALSE(...) DOCTEST_FAST_REQUIRE_UNARY_FALSE(__VA_ARGS__)
 
-#define TEST_CASE_TEMPLATE_INSTANTIATE DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE
+#define TEST_CASE_TEMPLATE_INSTANTIATE(id, ...) DOCTEST_TEST_CASE_TEMPLATE_INSTANTIATE(id, __VA_ARGS__)
 
 #endif // DOCTEST_CONFIG_NO_SHORT_MACRO_NAMES
 
-#if !defined(DOCTEST_CONFIG_DISABLE)
+#ifndef DOCTEST_CONFIG_DISABLE
 
 // this is here to clear the 'current test suite' for the current translation unit - at the top
 DOCTEST_TEST_SUITE_END();
-
-// add stringification for primitive/fundamental types
-namespace doctest { namespace detail {
-    DOCTEST_TYPE_TO_STRING_IMPL(bool)
-    DOCTEST_TYPE_TO_STRING_IMPL(float)
-    DOCTEST_TYPE_TO_STRING_IMPL(double)
-    DOCTEST_TYPE_TO_STRING_IMPL(long double)
-    DOCTEST_TYPE_TO_STRING_IMPL(char)
-    DOCTEST_TYPE_TO_STRING_IMPL(signed char)
-    DOCTEST_TYPE_TO_STRING_IMPL(unsigned char)
-#if !DOCTEST_MSVC || defined(_NATIVE_WCHAR_T_DEFINED)
-    DOCTEST_TYPE_TO_STRING_IMPL(wchar_t)
-#endif // not MSVC or wchar_t support enabled
-    DOCTEST_TYPE_TO_STRING_IMPL(short int)
-    DOCTEST_TYPE_TO_STRING_IMPL(unsigned short int)
-    DOCTEST_TYPE_TO_STRING_IMPL(int)
-    DOCTEST_TYPE_TO_STRING_IMPL(unsigned int)
-    DOCTEST_TYPE_TO_STRING_IMPL(long int)
-    DOCTEST_TYPE_TO_STRING_IMPL(unsigned long int)
-    DOCTEST_TYPE_TO_STRING_IMPL(long long int)
-    DOCTEST_TYPE_TO_STRING_IMPL(unsigned long long int)
-}} // namespace doctest::detail
 
 #endif // DOCTEST_CONFIG_DISABLE
 
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 DOCTEST_GCC_SUPPRESS_WARNING_POP
+
+DOCTEST_SUPPRESS_COMMON_WARNINGS_POP
 
 #endif // DOCTEST_LIBRARY_INCLUDED
 
@@ -2645,13 +3059,11 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wunused-macros")
 
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
 
+DOCTEST_SUPPRESS_COMMON_WARNINGS_PUSH
+
 DOCTEST_CLANG_SUPPRESS_WARNING_PUSH
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wunknown-pragmas")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wpadded")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wweak-vtables")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wglobal-constructors")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wexit-time-destructors")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-prototypes")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wsign-conversion")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wshorten-64-to-32")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-variable-declarations")
@@ -2659,64 +3071,35 @@ DOCTEST_CLANG_SUPPRESS_WARNING("-Wswitch")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wswitch-enum")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wcovered-switch-default")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-noreturn")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-local-typedef")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wdisabled-macro-expansion")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-braces")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wmissing-field-initializers")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat")
-DOCTEST_CLANG_SUPPRESS_WARNING("-Wc++98-compat-pedantic")
 DOCTEST_CLANG_SUPPRESS_WARNING("-Wunused-member-function")
+DOCTEST_CLANG_SUPPRESS_WARNING("-Wnonportable-system-include-path")
 
 DOCTEST_GCC_SUPPRESS_WARNING_PUSH
-DOCTEST_GCC_SUPPRESS_WARNING("-Wunknown-pragmas")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wpragmas")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wconversion")
-DOCTEST_GCC_SUPPRESS_WARNING("-Weffc++")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wsign-conversion")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-overflow")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wstrict-aliasing")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-field-initializers")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-braces")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wmissing-declarations")
-DOCTEST_GCC_SUPPRESS_WARNING("-Winline")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch-enum")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wswitch-default")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wunsafe-loop-optimizations")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wold-style-cast")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wunused-local-typedefs")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wuseless-cast")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wunused-function")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wmultiple-inheritance")
-DOCTEST_GCC_SUPPRESS_WARNING("-Wnoexcept")
 DOCTEST_GCC_SUPPRESS_WARNING("-Wsuggest-attribute")
 
 DOCTEST_MSVC_SUPPRESS_WARNING_PUSH
-DOCTEST_MSVC_SUPPRESS_WARNING(4616) // invalid compiler warning
-DOCTEST_MSVC_SUPPRESS_WARNING(4619) // invalid compiler warning
-DOCTEST_MSVC_SUPPRESS_WARNING(4996) // The compiler encountered a deprecated declaration
 DOCTEST_MSVC_SUPPRESS_WARNING(4267) // 'var' : conversion from 'x' to 'y', possible loss of data
-DOCTEST_MSVC_SUPPRESS_WARNING(4706) // assignment within conditional expression
-DOCTEST_MSVC_SUPPRESS_WARNING(4512) // 'class' : assignment operator could not be generated
-DOCTEST_MSVC_SUPPRESS_WARNING(4127) // conditional expression is constant
 DOCTEST_MSVC_SUPPRESS_WARNING(4530) // C++ exception handler used, but unwind semantics not enabled
 DOCTEST_MSVC_SUPPRESS_WARNING(4577) // 'noexcept' used with no exception handling mode specified
 DOCTEST_MSVC_SUPPRESS_WARNING(4774) // format string expected in argument is not a string literal
 DOCTEST_MSVC_SUPPRESS_WARNING(4365) // conversion from 'int' to 'unsigned', signed/unsigned mismatch
-DOCTEST_MSVC_SUPPRESS_WARNING(4820) // padding in structs
-DOCTEST_MSVC_SUPPRESS_WARNING(4640) // construction of local static object is not thread-safe
 DOCTEST_MSVC_SUPPRESS_WARNING(5039) // pointer to potentially throwing function passed to extern C
-DOCTEST_MSVC_SUPPRESS_WARNING(5045) // Spectre mitigation stuff
-DOCTEST_MSVC_SUPPRESS_WARNING(4626) // assignment operator was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(5027) // move assignment operator was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(5026) // move constructor was implicitly defined as deleted
-DOCTEST_MSVC_SUPPRESS_WARNING(4625) // copy constructor was implicitly defined as deleted
 DOCTEST_MSVC_SUPPRESS_WARNING(4800) // forcing value to bool 'true' or 'false' (performance warning)
-// static analysis
-DOCTEST_MSVC_SUPPRESS_WARNING(26439) // This kind of function may not throw. Declare it 'noexcept'
-DOCTEST_MSVC_SUPPRESS_WARNING(26495) // Always initialize a member variable
-DOCTEST_MSVC_SUPPRESS_WARNING(26451) // Arithmetic overflow ...
-DOCTEST_MSVC_SUPPRESS_WARNING(26444) // Avoid unnamed objects with custom construction and dtor...
+DOCTEST_MSVC_SUPPRESS_WARNING(5245) // unreferenced function with internal linkage has been removed
 
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 
@@ -2724,7 +3107,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <ctime>
 #include <cmath>
 #include <climits>
-// borland (Embarcadero) compiler requires math.h and not cmath - https://github.com/onqtam/doctest/pull/37
+// borland (Embarcadero) compiler requires math.h and not cmath - https://github.com/doctest/doctest/pull/37
 #ifdef __BORLANDC__
 #include <math.h>
 #endif // __BORLANDC__
@@ -2740,18 +3123,27 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <algorithm>
 #include <iomanip>
 #include <vector>
+#ifndef DOCTEST_CONFIG_NO_MULTITHREADING
 #include <atomic>
 #include <mutex>
+#define DOCTEST_DECLARE_MUTEX(name) std::mutex name;
+#define DOCTEST_DECLARE_STATIC_MUTEX(name) static DOCTEST_DECLARE_MUTEX(name)
+#define DOCTEST_LOCK_MUTEX(name) std::lock_guard<std::mutex> DOCTEST_ANONYMOUS(DOCTEST_ANON_LOCK_)(name);
+#else // DOCTEST_CONFIG_NO_MULTITHREADING
+#define DOCTEST_DECLARE_MUTEX(name)
+#define DOCTEST_DECLARE_STATIC_MUTEX(name)
+#define DOCTEST_LOCK_MUTEX(name)
+#endif // DOCTEST_CONFIG_NO_MULTITHREADING
 #include <set>
 #include <map>
+#include <unordered_set>
 #include <exception>
 #include <stdexcept>
-#ifdef DOCTEST_CONFIG_POSIX_SIGNALS
 #include <csignal>
-#endif // DOCTEST_CONFIG_POSIX_SIGNALS
 #include <cfloat>
 #include <cctype>
 #include <cstdint>
+#include <string>
 
 #ifdef DOCTEST_PLATFORM_MAC
 #include <sys/types.h>
@@ -2773,7 +3165,7 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #ifdef __AFXDLL
 #include <AfxWin.h>
 #else
-#include <Windows.h>
+#include <windows.h>
 #endif
 #include <io.h>
 
@@ -2783,6 +3175,12 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_BEGIN
 #include <unistd.h>
 
 #endif // DOCTEST_PLATFORM_WINDOWS
+
+// this is a fix for https://github.com/doctest/doctest/issues/348
+// https://mail.gnome.org/archives/xml/2012-January/msg00000.html
+#if !defined(HAVE_UNISTD_H) && !defined(STDOUT_FILENO)
+#define STDOUT_FILENO fileno(stdout)
+#endif // HAVE_UNISTD_H
 
 DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 
@@ -2800,7 +3198,19 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #endif
 
 #ifndef DOCTEST_THREAD_LOCAL
+#if defined(DOCTEST_CONFIG_NO_MULTITHREADING) || DOCTEST_MSVC && (DOCTEST_MSVC < DOCTEST_COMPILER(19, 0, 0))
+#define DOCTEST_THREAD_LOCAL
+#else // DOCTEST_MSVC
 #define DOCTEST_THREAD_LOCAL thread_local
+#endif // DOCTEST_MSVC
+#endif // DOCTEST_THREAD_LOCAL
+
+#ifndef DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES
+#define DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES 32
+#endif
+
+#ifndef DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE
+#define DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE 64
 #endif
 
 #ifdef DOCTEST_CONFIG_NO_UNPREFIXED_OPTIONS
@@ -2809,12 +3219,38 @@ DOCTEST_MAKE_STD_HEADERS_CLEAN_FROM_WARNINGS_ON_WALL_END
 #define DOCTEST_OPTIONS_PREFIX_DISPLAY ""
 #endif
 
+#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
+#define DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
+#endif
+
+#ifndef DOCTEST_CDECL
+#define DOCTEST_CDECL __cdecl
+#endif
+
 namespace doctest {
 
 bool is_running_in_test = false;
 
 namespace {
     using namespace detail;
+
+    template <typename Ex>
+    DOCTEST_NORETURN void throw_exception(Ex const& e) {
+#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
+        throw e;
+#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
+        std::cerr << "doctest will terminate because it needed to throw an exception.\n"
+                  << "The message was: " << e.what() << '\n';
+        std::terminate();
+#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+    }
+
+#ifndef DOCTEST_INTERNAL_ERROR
+#define DOCTEST_INTERNAL_ERROR(msg)                                                                \
+    throw_exception(std::logic_error(                                                              \
+            __FILE__ ":" DOCTEST_TOSTR(__LINE__) ": Internal doctest error: " msg))
+#endif // DOCTEST_INTERNAL_ERROR
+
     // case insensitive strcmp
     int stricmp(const char* a, const char* b) {
         for(;; a++, b++) {
@@ -2822,20 +3258,6 @@ namespace {
             if(d != 0 || !*a)
                 return d;
         }
-    }
-
-    template <typename T>
-    String fpToString(T value, int precision) {
-        std::ostringstream oss;
-        oss << std::setprecision(precision) << std::fixed << value;
-        std::string d = oss.str();
-        size_t      i = d.find_last_not_of('0');
-        if(i != std::string::npos && i != d.size() - 1) {
-            if(d[i] == '.')
-                i++;
-            d = d.substr(0, i + 1);
-        }
-        return d.c_str();
     }
 
     struct Endianness
@@ -2858,60 +3280,69 @@ namespace {
 } // namespace
 
 namespace detail {
-    void my_memcpy(void* dest, const void* src, unsigned num) { memcpy(dest, src, num); }
+    DOCTEST_THREAD_LOCAL class
+    {
+        std::vector<std::streampos> stack;
+        std::stringstream           ss;
 
-    String rawMemoryToString(const void* object, unsigned size) {
-        // Reverse order for little endian architectures
-        int i = 0, end = static_cast<int>(size), inc = 1;
-        if(Endianness::which() == Endianness::Little) {
-            i   = end - 1;
-            end = inc = -1;
+    public:
+        std::ostream* push() {
+            stack.push_back(ss.tellp());
+            return &ss;
         }
 
-        unsigned const char* bytes = static_cast<unsigned const char*>(object);
-        std::ostringstream   oss;
-        oss << "0x" << std::setfill('0') << std::hex;
-        for(; i != end; i += inc)
-            oss << std::setw(2) << static_cast<unsigned>(bytes[i]);
-        return oss.str().c_str();
+        String pop() {
+            if (stack.empty())
+                DOCTEST_INTERNAL_ERROR("TLSS was empty when trying to pop!");
+
+            std::streampos pos = stack.back();
+            stack.pop_back();
+            unsigned sz = static_cast<unsigned>(ss.tellp() - pos);
+            ss.rdbuf()->pubseekpos(pos, std::ios::in | std::ios::out);
+            return String(ss, sz);
+        }
+    } g_oss;
+
+    std::ostream* tlssPush() {
+        return g_oss.push();
     }
 
-    DOCTEST_THREAD_LOCAL std::ostringstream g_oss; // NOLINT(cert-err58-cpp)
-
-    std::ostream* getTlsOss() {
-        g_oss.clear(); // there shouldn't be anything worth clearing in the flags
-        g_oss.str(""); // the slow way of resetting a string stream
-        //g_oss.seekp(0); // optimal reset - as seen here: https://stackoverflow.com/a/624291/3162383
-        return &g_oss;
-    }
-
-    String getTlsOssResult() {
-        //g_oss << std::ends; // needed - as shown here: https://stackoverflow.com/a/624291/3162383
-        return g_oss.str().c_str();
+    String tlssPop() {
+        return g_oss.pop();
     }
 
 #ifndef DOCTEST_CONFIG_DISABLE
 
-    typedef uint64_t UInt64;
+namespace timer_large_integer
+{
+    
+#if defined(DOCTEST_PLATFORM_WINDOWS)
+    using type = ULONGLONG;
+#else // DOCTEST_PLATFORM_WINDOWS
+    using type = std::uint64_t;
+#endif // DOCTEST_PLATFORM_WINDOWS
+}
+
+using ticks_t = timer_large_integer::type;
 
 #ifdef DOCTEST_CONFIG_GETCURRENTTICKS
-    UInt64 getCurrentTicks() { return DOCTEST_CONFIG_GETCURRENTTICKS(); }
+    ticks_t getCurrentTicks() { return DOCTEST_CONFIG_GETCURRENTTICKS(); }
 #elif defined(DOCTEST_PLATFORM_WINDOWS)
-    UInt64 getCurrentTicks() {
-        static UInt64 hz = 0, hzo = 0;
-        if(!hz) {
-            QueryPerformanceFrequency(reinterpret_cast<LARGE_INTEGER*>(&hz));
-            QueryPerformanceCounter(reinterpret_cast<LARGE_INTEGER*>(&hzo));
+    ticks_t getCurrentTicks() {
+        static LARGE_INTEGER hz = { {0} }, hzo = { {0} };
+        if(!hz.QuadPart) {
+            QueryPerformanceFrequency(&hz);
+            QueryPerformanceCounter(&hzo);
         }
-        UInt64 t;
-        QueryPerformanceCounter(reinterpret_cast<LARGE_INTEGER*>(&t));
-        return ((t - hzo) * 1000000) / hz;
+        LARGE_INTEGER t;
+        QueryPerformanceCounter(&t);
+        return ((t.QuadPart - hzo.QuadPart) * LONGLONG(1000000)) / hz.QuadPart;
     }
 #else  // DOCTEST_PLATFORM_WINDOWS
-    UInt64 getCurrentTicks() {
+    ticks_t getCurrentTicks() {
         timeval t;
         gettimeofday(&t, nullptr);
-        return static_cast<UInt64>(t.tv_sec) * 1000000 + static_cast<UInt64>(t.tv_usec);
+        return static_cast<ticks_t>(t.tv_sec) * 1000000 + static_cast<ticks_t>(t.tv_usec);
     }
 #endif // DOCTEST_PLATFORM_WINDOWS
 
@@ -2924,23 +3355,115 @@ namespace detail {
         //unsigned int getElapsedMilliseconds() const {
         //    return static_cast<unsigned int>(getElapsedMicroseconds() / 1000);
         //}
-        double getElapsedSeconds() const { return getElapsedMicroseconds() / 1000000.0; }
+        double getElapsedSeconds() const { return static_cast<double>(getCurrentTicks() - m_ticks) / 1000000.0; }
 
     private:
-        UInt64 m_ticks = 0;
+        ticks_t m_ticks = 0;
     };
+
+#ifdef DOCTEST_CONFIG_NO_MULTITHREADING
+    template <typename T>
+    using Atomic = T;
+#else // DOCTEST_CONFIG_NO_MULTITHREADING
+    template <typename T>
+    using Atomic = std::atomic<T>;
+#endif // DOCTEST_CONFIG_NO_MULTITHREADING
+
+#if defined(DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS) || defined(DOCTEST_CONFIG_NO_MULTITHREADING)
+    template <typename T>
+    using MultiLaneAtomic = Atomic<T>;
+#else // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
+    // Provides a multilane implementation of an atomic variable that supports add, sub, load,
+    // store. Instead of using a single atomic variable, this splits up into multiple ones,
+    // each sitting on a separate cache line. The goal is to provide a speedup when most
+    // operations are modifying. It achieves this with two properties:
+    //
+    // * Multiple atomics are used, so chance of congestion from the same atomic is reduced.
+    // * Each atomic sits on a separate cache line, so false sharing is reduced.
+    //
+    // The disadvantage is that there is a small overhead due to the use of TLS, and load/store
+    // is slower because all atomics have to be accessed.
+    template <typename T>
+    class MultiLaneAtomic
+    {
+        struct CacheLineAlignedAtomic
+        {
+            Atomic<T> atomic{};
+            char padding[DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE - sizeof(Atomic<T>)];
+        };
+        CacheLineAlignedAtomic m_atomics[DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES];
+
+        static_assert(sizeof(CacheLineAlignedAtomic) == DOCTEST_MULTI_LANE_ATOMICS_CACHE_LINE_SIZE,
+                      "guarantee one atomic takes exactly one cache line");
+
+    public:
+        T operator++() DOCTEST_NOEXCEPT { return fetch_add(1) + 1; }
+
+        T operator++(int) DOCTEST_NOEXCEPT { return fetch_add(1); }
+
+        T fetch_add(T arg, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+            return myAtomic().fetch_add(arg, order);
+        }
+
+        T fetch_sub(T arg, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+            return myAtomic().fetch_sub(arg, order);
+        }
+
+        operator T() const DOCTEST_NOEXCEPT { return load(); }
+
+        T load(std::memory_order order = std::memory_order_seq_cst) const DOCTEST_NOEXCEPT {
+            auto result = T();
+            for(auto const& c : m_atomics) {
+                result += c.atomic.load(order);
+            }
+            return result;
+        }
+
+        T operator=(T desired) DOCTEST_NOEXCEPT { // lgtm [cpp/assignment-does-not-return-this]
+            store(desired);
+            return desired;
+        }
+
+        void store(T desired, std::memory_order order = std::memory_order_seq_cst) DOCTEST_NOEXCEPT {
+            // first value becomes desired", all others become 0.
+            for(auto& c : m_atomics) {
+                c.atomic.store(desired, order);
+                desired = {};
+            }
+        }
+
+    private:
+        // Each thread has a different atomic that it operates on. If more than NumLanes threads
+        // use this, some will use the same atomic. So performance will degrade a bit, but still
+        // everything will work.
+        //
+        // The logic here is a bit tricky. The call should be as fast as possible, so that there
+        // is minimal to no overhead in determining the correct atomic for the current thread.
+        //
+        // 1. A global static counter laneCounter counts continuously up.
+        // 2. Each successive thread will use modulo operation of that counter so it gets an atomic
+        //    assigned in a round-robin fashion.
+        // 3. This tlsLaneIdx is stored in the thread local data, so it is directly available with
+        //    little overhead.
+        Atomic<T>& myAtomic() DOCTEST_NOEXCEPT {
+            static Atomic<size_t> laneCounter;
+            DOCTEST_THREAD_LOCAL size_t tlsLaneIdx =
+                    laneCounter++ % DOCTEST_MULTI_LANE_ATOMICS_THREAD_LANES;
+
+            return m_atomics[tlsLaneIdx].atomic;
+        }
+    };
+#endif // DOCTEST_CONFIG_NO_MULTI_LANE_ATOMICS
 
     // this holds both parameters from the command line and runtime data for tests
     struct ContextState : ContextOptions, TestRunStats, CurrentTestCaseStats
     {
-        std::atomic<int> numAssertsCurrentTest_atomic;
-        std::atomic<int> numAssertsFailedCurrentTest_atomic;
+        MultiLaneAtomic<int> numAssertsCurrentTest_atomic;
+        MultiLaneAtomic<int> numAssertsFailedCurrentTest_atomic;
 
         std::vector<std::vector<String>> filters = decltype(filters)(9); // 9 different filters
 
         std::vector<IReporter*> reporters_currently_used;
-
-        const TestCase* currentTest = nullptr;
 
         assert_handler ah = nullptr;
 
@@ -2949,10 +3472,12 @@ namespace detail {
         std::vector<String> stringifiedContexts; // logging from INFO() due to an exception
 
         // stuff for subcases
-        std::set<SubcaseSignature> subcasesPassed;
-        std::set<int>              subcasesEnteredLevels;
-        int                        subcasesCurrentLevel;
-        bool                       should_reenter;
+        bool reachedLeaf;
+        std::vector<SubcaseSignature> subcaseStack;
+        std::vector<SubcaseSignature> nextSubcaseStack;
+        std::unordered_set<unsigned long long> fullyTraversedSubcases;
+        size_t currentSubcaseDepth;
+        Atomic<bool> shouldLogCurrentException;
 
         void resetRunData() {
             numTestCases                = 0;
@@ -3002,7 +3527,8 @@ namespace detail {
                               (TestCaseFailureReason::FailedExactlyNumTimes & failure_flags);
 
             // if any subcase has failed - the whole test case has failed
-            if(failure_flags && !ok_to_fail)
+            testCaseSuccess = !(failure_flags && !ok_to_fail);
+            if(!testCaseSuccess)
                 numTestCasesFailed++;
         }
     };
@@ -3017,22 +3543,37 @@ namespace detail {
 #endif // DOCTEST_CONFIG_DISABLE
 } // namespace detail
 
-void String::setOnHeap() { *reinterpret_cast<unsigned char*>(&buf[last]) = 128; }
-void String::setLast(unsigned in) { buf[last] = char(in); }
+char* String::allocate(size_type sz) {
+    if (sz <= last) {
+        buf[sz] = '\0';
+        setLast(last - sz);
+        return buf;
+    } else {
+        setOnHeap();
+        data.size = sz;
+        data.capacity = data.size + 1;
+        data.ptr = new char[data.capacity];
+        data.ptr[sz] = '\0';
+        return data.ptr;
+    }
+}
+
+void String::setOnHeap() noexcept { *reinterpret_cast<unsigned char*>(&buf[last]) = 128; }
+void String::setLast(size_type in) noexcept { buf[last] = char(in); }
+void String::setSize(size_type sz) noexcept {
+    if (isOnStack()) { buf[sz] = '\0'; setLast(last - sz); }
+    else { data.ptr[sz] = '\0'; data.size = sz; }
+}
 
 void String::copy(const String& other) {
     if(other.isOnStack()) {
         memcpy(buf, other.buf, len);
     } else {
-        setOnHeap();
-        data.size     = other.data.size;
-        data.capacity = data.size + 1;
-        data.ptr      = new char[data.capacity];
-        memcpy(data.ptr, other.data.ptr, data.size + 1);
+        memcpy(allocate(other.data.size), other.data.ptr, other.data.size);
     }
 }
 
-String::String() {
+String::String() noexcept {
     buf[0] = '\0';
     setLast();
 }
@@ -3040,22 +3581,17 @@ String::String() {
 String::~String() {
     if(!isOnStack())
         delete[] data.ptr;
-}
+} // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
 
 String::String(const char* in)
         : String(in, strlen(in)) {}
 
-String::String(const char* in, unsigned in_size) {
-    if(in_size <= last) {
-        memcpy(buf, in, in_size + 1);
-        setLast(last - in_size);
-    } else {
-        setOnHeap();
-        data.size     = in_size;
-        data.capacity = data.size + 1;
-        data.ptr      = new char[data.capacity];
-        memcpy(data.ptr, in, in_size + 1);
-    }
+String::String(const char* in, size_type in_size) {
+    memcpy(allocate(in_size), in, in_size);
+}
+
+String::String(std::istream& in, size_type in_size) {
+    in.read(allocate(in_size), in_size);
 }
 
 String::String(const String& other) { copy(other); }
@@ -3072,13 +3608,14 @@ String& String::operator=(const String& other) {
 }
 
 String& String::operator+=(const String& other) {
-    const unsigned my_old_size = size();
-    const unsigned other_size  = other.size();
-    const unsigned total_size  = my_old_size + other_size;
+    const size_type my_old_size = size();
+    const size_type other_size  = other.size();
+    const size_type total_size  = my_old_size + other_size;
     if(isOnStack()) {
         if(total_size < len) {
             // append to the current stack space
             memcpy(buf + my_old_size, other.c_str(), other_size + 1);
+            // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks)
             setLast(last - total_size);
         } else {
             // alloc new chunk
@@ -3120,15 +3657,13 @@ String& String::operator+=(const String& other) {
     return *this;
 }
 
-String String::operator+(const String& other) const { return String(*this) += other; }
-
-String::String(String&& other) {
+String::String(String&& other) noexcept {
     memcpy(buf, other.buf, len);
     other.buf[0] = '\0';
     other.setLast();
 }
 
-String& String::operator=(String&& other) {
+String& String::operator=(String&& other) noexcept {
     if(this != &other) {
         if(!isOnStack())
             delete[] data.ptr;
@@ -3139,33 +3674,63 @@ String& String::operator=(String&& other) {
     return *this;
 }
 
-char String::operator[](unsigned i) const {
-    return const_cast<String*>(this)->operator[](i); // NOLINT
+char String::operator[](size_type i) const {
+    return const_cast<String*>(this)->operator[](i);
 }
 
-char& String::operator[](unsigned i) {
+char& String::operator[](size_type i) {
     if(isOnStack())
         return reinterpret_cast<char*>(buf)[i];
     return data.ptr[i];
 }
 
 DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wmaybe-uninitialized")
-unsigned String::size() const {
+String::size_type String::size() const {
     if(isOnStack())
-        return last - (unsigned(buf[last]) & 31); // using "last" would work only if "len" is 32
+        return last - (size_type(buf[last]) & 31); // using "last" would work only if "len" is 32
     return data.size;
 }
 DOCTEST_GCC_SUPPRESS_WARNING_POP
 
-unsigned String::capacity() const {
+String::size_type String::capacity() const {
     if(isOnStack())
         return len;
     return data.capacity;
 }
 
+String String::substr(size_type pos, size_type cnt) && {
+    cnt = std::min(cnt, size() - 1 - pos);
+    char* cptr = c_str();
+    memmove(cptr, cptr + pos, cnt);
+    setSize(cnt);
+    return std::move(*this);
+}
+
+String String::substr(size_type pos, size_type cnt) const & {
+    cnt = std::min(cnt, size() - 1 - pos);
+    return String{ c_str() + pos, cnt };
+}
+
+String::size_type String::find(char ch, size_type pos) const {
+    const char* begin = c_str();
+    const char* end = begin + size();
+    const char* it = begin + pos;
+    for (; it < end && *it != ch; it++);
+    if (it < end) { return static_cast<size_type>(it - begin); }
+    else { return npos; }
+}
+
+String::size_type String::rfind(char ch, size_type pos) const {
+    const char* begin = c_str();
+    const char* it = begin + std::min(pos, size() - 1);
+    for (; it >= begin && *it != ch; it--);
+    if (it >= begin) { return static_cast<size_type>(it - begin); }
+    else { return npos; }
+}
+
 int String::compare(const char* other, bool no_case) const {
     if(no_case)
-        return stricmp(c_str(), other);
+        return doctest::stricmp(c_str(), other);
     return std::strcmp(c_str(), other);
 }
 
@@ -3173,16 +3738,31 @@ int String::compare(const String& other, bool no_case) const {
     return compare(other.c_str(), no_case);
 }
 
-// clang-format off
+String operator+(const String& lhs, const String& rhs) { return  String(lhs) += rhs; }
+
 bool operator==(const String& lhs, const String& rhs) { return lhs.compare(rhs) == 0; }
 bool operator!=(const String& lhs, const String& rhs) { return lhs.compare(rhs) != 0; }
 bool operator< (const String& lhs, const String& rhs) { return lhs.compare(rhs) < 0; }
 bool operator> (const String& lhs, const String& rhs) { return lhs.compare(rhs) > 0; }
 bool operator<=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lhs.compare(rhs) < 0 : true; }
 bool operator>=(const String& lhs, const String& rhs) { return (lhs != rhs) ? lhs.compare(rhs) > 0 : true; }
-// clang-format on
 
 std::ostream& operator<<(std::ostream& s, const String& in) { return s << in.c_str(); }
+
+Contains::Contains(const String& str) : string(str) { }
+
+bool Contains::checkWith(const String& other) const {
+    return strstr(other.c_str(), string.c_str()) != nullptr;
+}
+
+String toString(const Contains& in) {
+    return "Contains( " + in.string + " )";
+}
+
+bool operator==(const String& lhs, const Contains& rhs) { return rhs.checkWith(lhs); }
+bool operator==(const Contains& lhs, const String& rhs) { return lhs.checkWith(rhs); }
+bool operator!=(const String& lhs, const Contains& rhs) { return !rhs.checkWith(lhs); }
+bool operator!=(const Contains& lhs, const String& rhs) { return !lhs.checkWith(rhs); }
 
 namespace {
     void color_to_stream(std::ostream&, Color::Enum) DOCTEST_BRANCH_ON_DISABLED({}, ;)
@@ -3197,60 +3777,42 @@ namespace Color {
 
 // clang-format off
 const char* assertString(assertType::Enum at) {
-    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4062) // enum 'x' in switch of enum 'y' is not handled
-    switch(at) {  //!OCLINT missing default in switch statements
-        case assertType::DT_WARN                    : return "WARN";
-        case assertType::DT_CHECK                   : return "CHECK";
-        case assertType::DT_REQUIRE                 : return "REQUIRE";
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4061) // enum 'x' in switch of enum 'y' is not explicitely handled
+    #define DOCTEST_GENERATE_ASSERT_TYPE_CASE(assert_type) case assertType::DT_ ## assert_type: return #assert_type
+    #define DOCTEST_GENERATE_ASSERT_TYPE_CASES(assert_type) \
+        DOCTEST_GENERATE_ASSERT_TYPE_CASE(WARN_ ## assert_type); \
+        DOCTEST_GENERATE_ASSERT_TYPE_CASE(CHECK_ ## assert_type); \
+        DOCTEST_GENERATE_ASSERT_TYPE_CASE(REQUIRE_ ## assert_type)
+    switch(at) {
+        DOCTEST_GENERATE_ASSERT_TYPE_CASE(WARN);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASE(CHECK);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASE(REQUIRE);
 
-        case assertType::DT_WARN_FALSE              : return "WARN_FALSE";
-        case assertType::DT_CHECK_FALSE             : return "CHECK_FALSE";
-        case assertType::DT_REQUIRE_FALSE           : return "REQUIRE_FALSE";
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(FALSE);
 
-        case assertType::DT_WARN_THROWS             : return "WARN_THROWS";
-        case assertType::DT_CHECK_THROWS            : return "CHECK_THROWS";
-        case assertType::DT_REQUIRE_THROWS          : return "REQUIRE_THROWS";
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(THROWS);
 
-        case assertType::DT_WARN_THROWS_AS          : return "WARN_THROWS_AS";
-        case assertType::DT_CHECK_THROWS_AS         : return "CHECK_THROWS_AS";
-        case assertType::DT_REQUIRE_THROWS_AS       : return "REQUIRE_THROWS_AS";
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(THROWS_AS);
 
-        case assertType::DT_WARN_THROWS_WITH        : return "WARN_THROWS_WITH";
-        case assertType::DT_CHECK_THROWS_WITH       : return "CHECK_THROWS_WITH";
-        case assertType::DT_REQUIRE_THROWS_WITH     : return "REQUIRE_THROWS_WITH";
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(THROWS_WITH);
 
-        case assertType::DT_WARN_NOTHROW            : return "WARN_NOTHROW";
-        case assertType::DT_CHECK_NOTHROW           : return "CHECK_NOTHROW";
-        case assertType::DT_REQUIRE_NOTHROW         : return "REQUIRE_NOTHROW";
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(THROWS_WITH_AS);
 
-        case assertType::DT_WARN_EQ                 : return "WARN_EQ";
-        case assertType::DT_CHECK_EQ                : return "CHECK_EQ";
-        case assertType::DT_REQUIRE_EQ              : return "REQUIRE_EQ";
-        case assertType::DT_WARN_NE                 : return "WARN_NE";
-        case assertType::DT_CHECK_NE                : return "CHECK_NE";
-        case assertType::DT_REQUIRE_NE              : return "REQUIRE_NE";
-        case assertType::DT_WARN_GT                 : return "WARN_GT";
-        case assertType::DT_CHECK_GT                : return "CHECK_GT";
-        case assertType::DT_REQUIRE_GT              : return "REQUIRE_GT";
-        case assertType::DT_WARN_LT                 : return "WARN_LT";
-        case assertType::DT_CHECK_LT                : return "CHECK_LT";
-        case assertType::DT_REQUIRE_LT              : return "REQUIRE_LT";
-        case assertType::DT_WARN_GE                 : return "WARN_GE";
-        case assertType::DT_CHECK_GE                : return "CHECK_GE";
-        case assertType::DT_REQUIRE_GE              : return "REQUIRE_GE";
-        case assertType::DT_WARN_LE                 : return "WARN_LE";
-        case assertType::DT_CHECK_LE                : return "CHECK_LE";
-        case assertType::DT_REQUIRE_LE              : return "REQUIRE_LE";
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(NOTHROW);
 
-        case assertType::DT_WARN_UNARY              : return "WARN_UNARY";
-        case assertType::DT_CHECK_UNARY             : return "CHECK_UNARY";
-        case assertType::DT_REQUIRE_UNARY           : return "REQUIRE_UNARY";
-        case assertType::DT_WARN_UNARY_FALSE        : return "WARN_UNARY_FALSE";
-        case assertType::DT_CHECK_UNARY_FALSE       : return "CHECK_UNARY_FALSE";
-        case assertType::DT_REQUIRE_UNARY_FALSE     : return "REQUIRE_UNARY_FALSE";
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(EQ);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(NE);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(GT);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(LT);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(GE);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(LE);
+
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(UNARY);
+        DOCTEST_GENERATE_ASSERT_TYPE_CASES(UNARY_FALSE);
+
+        default: DOCTEST_INTERNAL_ERROR("Tried stringifying invalid assert type!");
     }
     DOCTEST_MSVC_SUPPRESS_WARNING_POP
-    return "";
 }
 // clang-format on
 
@@ -3268,6 +3830,7 @@ DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
 DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wnull-dereference")
 // depending on the current options this will remove the path of filenames
 const char* skipPathFromFilename(const char* file) {
+#ifndef DOCTEST_CONFIG_DISABLE
     if(getContextOptions()->no_path_in_filenames) {
         auto back    = std::strrchr(file, '\\');
         auto forward = std::strrchr(file, '/');
@@ -3277,80 +3840,77 @@ const char* skipPathFromFilename(const char* file) {
             return forward + 1;
         }
     }
+#endif // DOCTEST_CONFIG_DISABLE
     return file;
 }
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
 DOCTEST_GCC_SUPPRESS_WARNING_POP
 
-DOCTEST_DEFINE_DEFAULTS(TestCaseData);
-DOCTEST_DEFINE_COPIES(TestCaseData);
-
-DOCTEST_DEFINE_DEFAULTS(AssertData);
-
-DOCTEST_DEFINE_DEFAULTS(MessageData);
-
-SubcaseSignature::SubcaseSignature(const char* name, const char* file, int line)
-        : m_name(name)
-        , m_file(file)
-        , m_line(line) {}
-
-DOCTEST_DEFINE_DEFAULTS(SubcaseSignature);
-DOCTEST_DEFINE_COPIES(SubcaseSignature);
+bool SubcaseSignature::operator==(const SubcaseSignature& other) const {
+    return m_line == other.m_line
+        && std::strcmp(m_file, other.m_file) == 0
+        && m_name == other.m_name;
+}
 
 bool SubcaseSignature::operator<(const SubcaseSignature& other) const {
     if(m_line != other.m_line)
         return m_line < other.m_line;
     if(std::strcmp(m_file, other.m_file) != 0)
         return std::strcmp(m_file, other.m_file) < 0;
-    return std::strcmp(m_name, other.m_name) < 0;
+    return m_name.compare(other.m_name) < 0;
 }
 
-IContextScope::IContextScope()  = default;
-IContextScope::~IContextScope() = default;
+DOCTEST_DEFINE_INTERFACE(IContextScope)
 
-DOCTEST_DEFINE_DEFAULTS(ContextOptions);
-
-#ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-String toString(char* in) { return toString(static_cast<const char*>(in)); }
-String toString(const char* in) { return String("\"") + (in ? in : "{null string}") + "\""; }
-#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-String toString(bool in) { return in ? "true" : "false"; }
-String toString(float in) { return fpToString(in, 5) + "f"; }
-String toString(double in) { return fpToString(in, 10); }
-String toString(double long in) { return fpToString(in, 15); }
-
-#define DOCTEST_TO_STRING_OVERLOAD(type, fmt)                                                      \
-    String toString(type in) {                                                                     \
-        char buf[64];                                                                              \
-        std::sprintf(buf, fmt, in);                                                                \
-        return buf;                                                                                \
+namespace detail {
+    void filldata<const void*>::fill(std::ostream* stream, const void* in) {
+        if (in) { *stream << in; }
+        else { *stream << "nullptr"; }
     }
 
-DOCTEST_TO_STRING_OVERLOAD(char, "%d")
-DOCTEST_TO_STRING_OVERLOAD(char signed, "%d")
-DOCTEST_TO_STRING_OVERLOAD(char unsigned, "%u")
-DOCTEST_TO_STRING_OVERLOAD(int short, "%d")
-DOCTEST_TO_STRING_OVERLOAD(int short unsigned, "%u")
-DOCTEST_TO_STRING_OVERLOAD(int, "%d")
-DOCTEST_TO_STRING_OVERLOAD(unsigned, "%u")
-DOCTEST_TO_STRING_OVERLOAD(int long, "%ld")
-DOCTEST_TO_STRING_OVERLOAD(int long unsigned, "%lu")
-DOCTEST_TO_STRING_OVERLOAD(int long long, "%lld")
-DOCTEST_TO_STRING_OVERLOAD(int long long unsigned, "%llu")
+    template <typename T>
+    String toStreamLit(T t) {
+        std::ostream* os = tlssPush();
+        os->operator<<(t);
+        return tlssPop();
+    }
+}
 
-String toString(std::nullptr_t) { return "NULL"; }
+#ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
+String toString(const char* in) { return String("\"") + (in ? in : "{null string}") + "\""; }
+#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
 
 #if DOCTEST_MSVC >= DOCTEST_COMPILER(19, 20, 0)
-// see this issue on why this is needed: https://github.com/onqtam/doctest/issues/183
+// see this issue on why this is needed: https://github.com/doctest/doctest/issues/183
 String toString(const std::string& in) { return in.c_str(); }
 #endif // VS 2019
+
+String toString(String in) { return in; }
+
+String toString(std::nullptr_t) { return "nullptr"; }
+
+String toString(bool in) { return in ? "true" : "false"; }
+
+String toString(float in) { return toStreamLit(in); }
+String toString(double in) { return toStreamLit(in); }
+String toString(double long in) { return toStreamLit(in); }
+
+String toString(char in) { return toStreamLit(static_cast<signed>(in)); }
+String toString(char signed in) { return toStreamLit(static_cast<signed>(in)); }
+String toString(char unsigned in) { return toStreamLit(static_cast<unsigned>(in)); }
+String toString(short in) { return toStreamLit(in); }
+String toString(short unsigned in) { return toStreamLit(in); }
+String toString(signed in) { return toStreamLit(in); }
+String toString(unsigned in) { return toStreamLit(in); }
+String toString(long in) { return toStreamLit(in); }
+String toString(long unsigned in) { return toStreamLit(in); }
+String toString(long long in) { return toStreamLit(in); }
+String toString(long long unsigned in) { return toStreamLit(in); }
 
 Approx::Approx(double value)
         : m_epsilon(static_cast<double>(std::numeric_limits<float>::epsilon()) * 100)
         , m_scale(1.0)
         , m_value(value) {}
-
-DOCTEST_DEFINE_COPIES(Approx);
 
 Approx Approx::operator()(double value) const {
     Approx approx(value);
@@ -3386,9 +3946,24 @@ bool operator>(double lhs, const Approx& rhs) { return lhs > rhs.m_value && lhs 
 bool operator>(const Approx& lhs, double rhs) { return lhs.m_value > rhs && lhs != rhs; }
 
 String toString(const Approx& in) {
-    return String("Approx( ") + doctest::toString(in.m_value) + " )";
+    return "Approx( " + doctest::toString(in.m_value) + " )";
 }
 const ContextOptions* getContextOptions() { return DOCTEST_BRANCH_ON_DISABLED(nullptr, g_cs); }
+
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4738)
+template <typename F>
+IsNaN<F>::operator bool() const {
+    return std::isnan(value) ^ flipped;
+}
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
+template struct DOCTEST_INTERFACE_DEF IsNaN<float>;
+template struct DOCTEST_INTERFACE_DEF IsNaN<double>;
+template struct DOCTEST_INTERFACE_DEF IsNaN<long double>;
+template <typename F>
+String toString(IsNaN<F> in) { return String(in.flipped ? "! " : "") + "IsNaN( " + doctest::toString(in.value) + " )"; }
+String toString(IsNaN<float> in) { return toString<float>(in); }
+String toString(IsNaN<double> in) { return toString<double>(in); }
+String toString(IsNaN<double long> in) { return toString<double long>(in); }
 
 } // namespace doctest
 
@@ -3399,18 +3974,14 @@ Context::~Context() = default;
 void Context::applyCommandLine(int, const char* const*) {}
 void Context::addFilter(const char*, const char*) {}
 void Context::clearFilters() {}
+void Context::setOption(const char*, bool) {}
 void Context::setOption(const char*, int) {}
 void Context::setOption(const char*, const char*) {}
 bool Context::shouldExit() { return false; }
 void Context::setAsDefaultForAssertsOutOfTestCases() {}
 void Context::setAssertHandler(detail::assert_handler) {}
+void Context::setCout(std::ostream*) {}
 int  Context::run() { return 0; }
-
-DOCTEST_DEFINE_DEFAULTS(CurrentTestCaseStats);
-
-DOCTEST_DEFINE_DEFAULTS(TestRunStats);
-
-IReporter::~IReporter() = default;
 
 int                         IReporter::get_num_active_contexts() { return 0; }
 const IContextScope* const* IReporter::get_active_contexts() { return nullptr; }
@@ -3435,7 +4006,7 @@ int registerReporter(const char*, int, IReporter*) { return 0; }
 namespace doctest_detail_test_suite_ns {
 // holds the current test suite
 doctest::detail::TestSuite& getCurrentTestSuite() {
-    static doctest::detail::TestSuite data;
+    static doctest::detail::TestSuite data{};
     return data;
 }
 } // namespace doctest_detail_test_suite_ns
@@ -3444,7 +4015,7 @@ namespace doctest {
 namespace {
     // the int (priority) is part of the key for automatic sorting - sadly one can register a
     // reporter with a duplicate name and a different priority but hopefully that won't happen often :|
-    typedef std::map<std::pair<int, String>, reporterCreatorFunc> reporterMap;
+    using reporterMap = std::map<std::pair<int, String>, reporterCreatorFunc>;
 
     reporterMap& getReporters() {
         static reporterMap data;
@@ -3460,8 +4031,6 @@ namespace detail {
     for(auto& curr_rep : g_cs->reporters_currently_used)                                           \
     curr_rep->function(__VA_ARGS__)
 
-    DOCTEST_DEFINE_DEFAULTS(TestFailureException);
-    DOCTEST_DEFINE_COPIES(TestFailureException);
     bool checkIfShouldThrow(assertType::Enum at) {
         if(at & assertType::is_require) //!OCLINT bitwise operator in conditional
             return true;
@@ -3476,7 +4045,10 @@ namespace detail {
     }
 
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-    [[noreturn]] void throwException() { throw TestFailureException(); } // NOLINT(cert-err60-cpp)
+    DOCTEST_NORETURN void throwException() {
+        g_cs->shouldLogCurrentException = false;
+        throw TestFailureException(); // NOLINT(hicpp-exception-baseclass)
+    }
 #else // DOCTEST_CONFIG_NO_EXCEPTIONS
     void throwException() {}
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
@@ -3487,8 +4059,8 @@ namespace {
     // matching of a string against a wildcard mask (case sensitivity configurable) taken from
     // https://www.codeproject.com/Articles/1088/Wildcard-string-compare-globbing
     int wildcmp(const char* str, const char* wild, bool caseSensitive) {
-        const char* cp = nullptr;
-        const char* mp = nullptr;
+        const char* cp = str;
+        const char* mp = wild;
 
         while((*str) && (*wild != '*')) {
             if((caseSensitive ? (*wild != *str) : (tolower(*wild) != tolower(*str))) &&
@@ -3522,68 +4094,133 @@ namespace {
         return !*wild;
     }
 
-    //// C string hash function (djb2) - taken from http://www.cse.yorku.ca/~oz/hash.html
-    //unsigned hashStr(unsigned const char* str) {
-    //    unsigned long hash = 5381;
-    //    char          c;
-    //    while((c = *str++))
-    //        hash = ((hash << 5) + hash) + c; // hash * 33 + c
-    //    return hash;
-    //}
-
     // checks if the name matches any of the filters (and can be configured what to do when empty)
     bool matchesAny(const char* name, const std::vector<String>& filters, bool matchEmpty,
-                    bool caseSensitive) {
-        if(filters.empty() && matchEmpty)
+        bool caseSensitive) {
+        if (filters.empty() && matchEmpty)
             return true;
-        for(auto& curr : filters)
-            if(wildcmp(name, curr.c_str(), caseSensitive))
+        for (auto& curr : filters)
+            if (wildcmp(name, curr.c_str(), caseSensitive))
                 return true;
         return false;
     }
-} // namespace
-namespace detail {
 
-    Subcase::Subcase(const char* name, const char* file, int line)
-            : m_signature(name, file, line) {
-        ContextState* s = g_cs;
-
-        // if we have already completed it
-        if(s->subcasesPassed.count(m_signature) != 0)
-            return;
-
-        // check subcase filters
-        if(s->subcasesCurrentLevel < s->subcase_filter_levels) {
-            if(!matchesAny(m_signature.m_name, s->filters[6], true, s->case_sensitive))
-                return;
-            if(matchesAny(m_signature.m_name, s->filters[7], false, s->case_sensitive))
-                return;
-        }
-
-        // if a Subcase on the same level has already been entered
-        if(s->subcasesEnteredLevels.count(s->subcasesCurrentLevel) != 0) {
-            s->should_reenter = true;
-            return;
-        }
-
-        s->subcasesEnteredLevels.insert(s->subcasesCurrentLevel++);
-        m_entered = true;
-
-        DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
+    unsigned long long hash(unsigned long long a, unsigned long long b) {
+        return (a << 5) + b;
     }
 
-    Subcase::~Subcase() {
-        if(m_entered) {
-            ContextState* s = g_cs;
+    // C string hash function (djb2) - taken from http://www.cse.yorku.ca/~oz/hash.html
+    unsigned long long hash(const char* str) {
+        unsigned long long hash = 5381;
+        char c;
+        while ((c = *str++))
+            hash = ((hash << 5) + hash) + c; // hash * 33 + c
+        return hash;
+    }
 
-            s->subcasesCurrentLevel--;
-            // only mark the subcase as passed if no subcases have been skipped
-            if(s->should_reenter == false)
-                s->subcasesPassed.insert(m_signature);
+    unsigned long long hash(const SubcaseSignature& sig) {
+        return hash(hash(hash(sig.m_file), hash(sig.m_name.c_str())), sig.m_line);
+    }
+
+    unsigned long long hash(const std::vector<SubcaseSignature>& sigs, size_t count) {
+        unsigned long long running = 0;
+        auto end = sigs.begin() + count;
+        for (auto it = sigs.begin(); it != end; it++) {
+            running = hash(running, hash(*it));
+        }
+        return running;
+    }
+
+    unsigned long long hash(const std::vector<SubcaseSignature>& sigs) {
+        unsigned long long running = 0;
+        for (const SubcaseSignature& sig : sigs) {
+            running = hash(running, hash(sig));
+        }
+        return running;
+    }
+} // namespace
+namespace detail {
+    bool Subcase::checkFilters() {
+        if (g_cs->subcaseStack.size() < size_t(g_cs->subcase_filter_levels)) {
+            if (!matchesAny(m_signature.m_name.c_str(), g_cs->filters[6], true, g_cs->case_sensitive))
+                return true;
+            if (matchesAny(m_signature.m_name.c_str(), g_cs->filters[7], false, g_cs->case_sensitive))
+                return true;
+        }
+        return false;
+    }
+
+    Subcase::Subcase(const String& name, const char* file, int line)
+            : m_signature({name, file, line}) {
+        if (!g_cs->reachedLeaf) {
+            if (g_cs->nextSubcaseStack.size() <= g_cs->subcaseStack.size()
+                || g_cs->nextSubcaseStack[g_cs->subcaseStack.size()] == m_signature) {
+                // Going down.
+                if (checkFilters()) { return; }
+
+                g_cs->subcaseStack.push_back(m_signature);
+                g_cs->currentSubcaseDepth++;
+                m_entered = true;
+                DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
+            }
+        } else {
+            if (g_cs->subcaseStack[g_cs->currentSubcaseDepth] == m_signature) {
+                // This subcase is reentered via control flow.
+                g_cs->currentSubcaseDepth++;
+                m_entered = true;
+                DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_start, m_signature);
+            } else if (g_cs->nextSubcaseStack.size() <= g_cs->currentSubcaseDepth
+                    && g_cs->fullyTraversedSubcases.find(hash(hash(g_cs->subcaseStack, g_cs->currentSubcaseDepth), hash(m_signature)))
+                    == g_cs->fullyTraversedSubcases.end()) {
+                if (checkFilters()) { return; }
+                // This subcase is part of the one to be executed next.
+                g_cs->nextSubcaseStack.clear();
+                g_cs->nextSubcaseStack.insert(g_cs->nextSubcaseStack.end(),
+                    g_cs->subcaseStack.begin(), g_cs->subcaseStack.begin() + g_cs->currentSubcaseDepth);
+                g_cs->nextSubcaseStack.push_back(m_signature);
+            }
+        }
+    }
+
+    DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
+    DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+    DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+
+    Subcase::~Subcase() {
+        if (m_entered) {
+            g_cs->currentSubcaseDepth--;
+
+            if (!g_cs->reachedLeaf) {
+                // Leaf.
+                g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
+                g_cs->nextSubcaseStack.clear();
+                g_cs->reachedLeaf = true;
+            } else if (g_cs->nextSubcaseStack.empty()) {
+                // All children are finished.
+                g_cs->fullyTraversedSubcases.insert(hash(g_cs->subcaseStack));
+            }
+
+#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
+            if(std::uncaught_exceptions() > 0
+#else
+            if(std::uncaught_exception()
+#endif
+                && g_cs->shouldLogCurrentException) {
+                DOCTEST_ITERATE_THROUGH_REPORTERS(
+                        test_case_exception, {"exception thrown in subcase - will translate later "
+                                                "when the whole test case has been exited (cannot "
+                                                "translate while there is an active exception)",
+                                                false});
+                g_cs->shouldLogCurrentException = false;
+            }
 
             DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
         }
     }
+
+    DOCTEST_CLANG_SUPPRESS_WARNING_POP
+    DOCTEST_GCC_SUPPRESS_WARNING_POP
+    DOCTEST_MSVC_SUPPRESS_WARNING_POP
 
     Subcase::operator bool() const { return m_entered; }
 
@@ -3591,37 +4228,24 @@ namespace detail {
             : m_passed(passed)
             , m_decomp(decomposition) {}
 
-    DOCTEST_DEFINE_DEFAULTS(Result);
-    DOCTEST_DEFINE_COPIES(Result);
-
     ExpressionDecomposer::ExpressionDecomposer(assertType::Enum at)
             : m_at(at) {}
 
-    DOCTEST_DEFINE_DEFAULTS(ExpressionDecomposer);
-
-    DOCTEST_DEFINE_DEFAULTS(TestSuite);
-    DOCTEST_DEFINE_COPIES(TestSuite);
-
     TestSuite& TestSuite::operator*(const char* in) {
         m_test_suite = in;
-        // clear state
-        m_description       = nullptr;
-        m_skip              = false;
-        m_may_fail          = false;
-        m_should_fail       = false;
-        m_expected_failures = 0;
-        m_timeout           = 0;
         return *this;
     }
 
     TestCase::TestCase(funcType test, const char* file, unsigned line, const TestSuite& test_suite,
-                       const char* type, int template_id) {
+                       const String& type, int template_id) {
         m_file              = file;
         m_line              = line;
         m_name              = nullptr; // will be later overridden in operator*
         m_test_suite        = test_suite.m_test_suite;
         m_description       = test_suite.m_description;
         m_skip              = test_suite.m_skip;
+        m_no_breaks         = test_suite.m_no_breaks;
+        m_no_output         = test_suite.m_no_output;
         m_may_fail          = test_suite.m_may_fail;
         m_should_fail       = test_suite.m_should_fail;
         m_expected_failures = test_suite.m_expected_failures;
@@ -3632,18 +4256,14 @@ namespace detail {
         m_template_id = template_id;
     }
 
-    DOCTEST_DEFINE_DEFAULTS(TestCase);
-
     TestCase::TestCase(const TestCase& other)
             : TestCaseData() {
         *this = other;
     }
 
     DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(26434) // hides a non-virtual function
-    DOCTEST_MSVC_SUPPRESS_WARNING(26437)           // Do not slice
     TestCase& TestCase::operator=(const TestCase& other) {
-        static_cast<TestCaseData&>(*this) = static_cast<const TestCaseData&>(other);
-
+        TestCaseData::operator=(other);
         m_test        = other.m_test;
         m_type        = other.m_type;
         m_template_id = other.m_template_id;
@@ -3659,7 +4279,7 @@ namespace detail {
         m_name = in;
         // make a new name with an appended type for templated test case
         if(m_template_id != -1) {
-            m_full_name = String(m_name) + m_type;
+            m_full_name = String(m_name) + "<" + m_type + ">";
             // redirect the name to point to the newly constructed full name
             m_name = m_full_name.c_str();
         }
@@ -3667,25 +4287,31 @@ namespace detail {
     }
 
     bool TestCase::operator<(const TestCase& other) const {
+        // this will be used only to differentiate between test cases - not relevant for sorting
         if(m_line != other.m_line)
             return m_line < other.m_line;
-        const int file_cmp = std::strcmp(m_file, other.m_file);
+        const int name_cmp = strcmp(m_name, other.m_name);
+        if(name_cmp != 0)
+            return name_cmp < 0;
+        const int file_cmp = m_file.compare(other.m_file);
         if(file_cmp != 0)
             return file_cmp < 0;
         return m_template_id < other.m_template_id;
+    }
+
+    // all the registered tests
+    std::set<TestCase>& getRegisteredTests() {
+        static std::set<TestCase> data;
+        return data;
     }
 } // namespace detail
 namespace {
     using namespace detail;
     // for sorting tests by file/line
     bool fileOrderComparator(const TestCase* lhs, const TestCase* rhs) {
-#if DOCTEST_MSVC
         // this is needed because MSVC gives different case for drive letters
         // for __FILE__ when evaluated in a header and a source file
-        const int res = stricmp(lhs->m_file, rhs->m_file);
-#else  // MSVC
-        const int res = std::strcmp(lhs->m_file, rhs->m_file);
-#endif // MSVC
+        const int res = lhs->m_file.compare(rhs->m_file, bool(DOCTEST_MSVC));
         if(res != 0)
             return res < 0;
         if(lhs->m_line != rhs->m_line)
@@ -3709,39 +4335,10 @@ namespace {
         return suiteOrderComparator(lhs, rhs);
     }
 
-    // all the registered tests
-    std::set<TestCase>& getRegisteredTests() {
-        static std::set<TestCase> data;
-        return data;
-    }
-
-#ifdef DOCTEST_CONFIG_COLORS_WINDOWS
-    HANDLE g_stdoutHandle;
-    WORD   g_origFgAttrs;
-    WORD   g_origBgAttrs;
-    bool   g_attrsInitted = false;
-
-    int colors_init() {
-        if(!g_attrsInitted) {
-            g_stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-            g_attrsInitted = true;
-            CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
-            GetConsoleScreenBufferInfo(g_stdoutHandle, &csbiInfo);
-            g_origFgAttrs = csbiInfo.wAttributes & ~(BACKGROUND_GREEN | BACKGROUND_RED |
-                                                     BACKGROUND_BLUE | BACKGROUND_INTENSITY);
-            g_origBgAttrs = csbiInfo.wAttributes & ~(FOREGROUND_GREEN | FOREGROUND_RED |
-                                                     FOREGROUND_BLUE | FOREGROUND_INTENSITY);
-        }
-        return 0;
-    }
-
-    int dumy_init_console_colors = colors_init();
-#endif // DOCTEST_CONFIG_COLORS_WINDOWS
-
     DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
     void color_to_stream(std::ostream& s, Color::Enum code) {
-        ((void)s);    // for DOCTEST_CONFIG_COLORS_NONE or DOCTEST_CONFIG_COLORS_WINDOWS
-        ((void)code); // for DOCTEST_CONFIG_COLORS_NONE
+        static_cast<void>(s);    // for DOCTEST_CONFIG_COLORS_NONE or DOCTEST_CONFIG_COLORS_WINDOWS
+        static_cast<void>(code); // for DOCTEST_CONFIG_COLORS_NONE
 #ifdef DOCTEST_CONFIG_COLORS_ANSI
         if(g_no_colors ||
            (isatty(STDOUT_FILENO) == false && getContextOptions()->force_colors == false))
@@ -3771,10 +4368,26 @@ namespace {
 
 #ifdef DOCTEST_CONFIG_COLORS_WINDOWS
         if(g_no_colors ||
-           (isatty(fileno(stdout)) == false && getContextOptions()->force_colors == false))
+           (_isatty(_fileno(stdout)) == false && getContextOptions()->force_colors == false))
             return;
 
-#define DOCTEST_SET_ATTR(x) SetConsoleTextAttribute(g_stdoutHandle, x | g_origBgAttrs)
+        static struct ConsoleHelper {
+            HANDLE stdoutHandle;
+            WORD   origFgAttrs;
+            WORD   origBgAttrs;
+
+            ConsoleHelper() {
+                stdoutHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+                CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
+                GetConsoleScreenBufferInfo(stdoutHandle, &csbiInfo);
+                origFgAttrs = csbiInfo.wAttributes & ~(BACKGROUND_GREEN | BACKGROUND_RED |
+                    BACKGROUND_BLUE | BACKGROUND_INTENSITY);
+                origBgAttrs = csbiInfo.wAttributes & ~(FOREGROUND_GREEN | FOREGROUND_RED |
+                    FOREGROUND_BLUE | FOREGROUND_INTENSITY);
+            }
+        } ch;
+
+#define DOCTEST_SET_ATTR(x) SetConsoleTextAttribute(ch.stdoutHandle, x | ch.origBgAttrs)
 
         // clang-format off
         switch (code) {
@@ -3791,7 +4404,7 @@ namespace {
             case Color::BrightWhite: DOCTEST_SET_ATTR(FOREGROUND_INTENSITY | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_BLUE); break;
             case Color::None:
             case Color::Bright: // invalid
-            default:                 DOCTEST_SET_ATTR(g_origFgAttrs);
+            default:                 DOCTEST_SET_ATTR(ch.origFgAttrs);
         }
             // clang-format on
 #endif // DOCTEST_CONFIG_COLORS_WINDOWS
@@ -3844,9 +4457,33 @@ namespace detail {
         return 0;
     }
 
-#ifdef DOCTEST_PLATFORM_MAC
+#ifdef DOCTEST_IS_DEBUGGER_ACTIVE
+    bool isDebuggerActive() { return DOCTEST_IS_DEBUGGER_ACTIVE(); }
+#else // DOCTEST_IS_DEBUGGER_ACTIVE
+#ifdef DOCTEST_PLATFORM_LINUX
+    class ErrnoGuard {
+    public:
+        ErrnoGuard() : m_oldErrno(errno) {}
+        ~ErrnoGuard() { errno = m_oldErrno; }
+    private:
+        int m_oldErrno;
+    };
+    // See the comments in Catch2 for the reasoning behind this implementation:
+    // https://github.com/catchorg/Catch2/blob/v2.13.1/include/internal/catch_debugger.cpp#L79-L102
+    bool isDebuggerActive() {
+        ErrnoGuard guard;
+        std::ifstream in("/proc/self/status");
+        for(std::string line; std::getline(in, line);) {
+            static const int PREFIX_LEN = 11;
+            if(line.compare(0, PREFIX_LEN, "TracerPid:\t") == 0) {
+                return line.length() > PREFIX_LEN && line[PREFIX_LEN] != '0';
+            }
+        }
+        return false;
+    }
+#elif defined(DOCTEST_PLATFORM_MAC)
     // The following function is taken directly from the following technical note:
-    // http://developer.apple.com/library/mac/#qa/qa2004/qa1361.html
+    // https://developer.apple.com/library/archive/qa/qa1361/_index.html
     // Returns true if the current process is being debugged (either
     // running under the debugger or has a debugger attached post facto).
     bool isDebuggerActive() {
@@ -3871,11 +4508,12 @@ namespace detail {
         // We're being debugged if the P_TRACED flag is set.
         return ((info.kp_proc.p_flag & P_TRACED) != 0);
     }
-#elif DOCTEST_MSVC || defined(__MINGW32__)
+#elif DOCTEST_MSVC || defined(__MINGW32__) || defined(__MINGW64__)
     bool isDebuggerActive() { return ::IsDebuggerPresent() != 0; }
 #else
     bool isDebuggerActive() { return false; }
 #endif // Platform
+#endif // DOCTEST_IS_DEBUGGER_ACTIVE
 
     void registerExceptionTranslatorImpl(const IExceptionTranslator* et) {
         if(std::find(getExceptionTranslators().begin(), getExceptionTranslators().end(), et) ==
@@ -3883,68 +4521,53 @@ namespace detail {
             getExceptionTranslators().push_back(et);
     }
 
-#ifdef DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    void toStream(std::ostream* s, char* in) { *s << in; }
-    void toStream(std::ostream* s, const char* in) { *s << in; }
-#endif // DOCTEST_CONFIG_TREAT_CHAR_STAR_AS_STRING
-    void toStream(std::ostream* s, bool in) { *s << std::boolalpha << in << std::noboolalpha; }
-    void toStream(std::ostream* s, float in) { *s << in; }
-    void toStream(std::ostream* s, double in) { *s << in; }
-    void toStream(std::ostream* s, double long in) { *s << in; }
-
-    void toStream(std::ostream* s, char in) { *s << in; }
-    void toStream(std::ostream* s, char signed in) { *s << in; }
-    void toStream(std::ostream* s, char unsigned in) { *s << in; }
-    void toStream(std::ostream* s, int short in) { *s << in; }
-    void toStream(std::ostream* s, int short unsigned in) { *s << in; }
-    void toStream(std::ostream* s, int in) { *s << in; }
-    void toStream(std::ostream* s, int unsigned in) { *s << in; }
-    void toStream(std::ostream* s, int long in) { *s << in; }
-    void toStream(std::ostream* s, int long unsigned in) { *s << in; }
-    void toStream(std::ostream* s, int long long in) { *s << in; }
-    void toStream(std::ostream* s, int long long unsigned in) { *s << in; }
-
     DOCTEST_THREAD_LOCAL std::vector<IContextScope*> g_infoContexts; // for logging with INFO()
 
     ContextScopeBase::ContextScopeBase() {
         g_infoContexts.push_back(this);
     }
 
+    ContextScopeBase::ContextScopeBase(ContextScopeBase&& other) noexcept {
+        if (other.need_to_destroy) {
+            other.destroy();
+        }
+        other.need_to_destroy = false;
+        g_infoContexts.push_back(this);
+    }
+
     DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4996) // std::uncaught_exception is deprecated in C++17
     DOCTEST_GCC_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
     DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
+
     // destroy cannot be inlined into the destructor because that would mean calling stringify after
     // ContextScope has been destroyed (base class destructors run after derived class destructors).
     // Instead, ContextScope calls this method directly from its destructor.
     void ContextScopeBase::destroy() {
+#if defined(__cpp_lib_uncaught_exceptions) && __cpp_lib_uncaught_exceptions >= 201411L && (!defined(__MAC_OS_X_VERSION_MIN_REQUIRED) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
+        if(std::uncaught_exceptions() > 0) {
+#else
         if(std::uncaught_exception()) {
+#endif
             std::ostringstream s;
             this->stringify(&s);
             g_cs->stringifiedContexts.push_back(s.str().c_str());
         }
         g_infoContexts.pop_back();
     }
+
     DOCTEST_CLANG_SUPPRESS_WARNING_POP
     DOCTEST_GCC_SUPPRESS_WARNING_POP
     DOCTEST_MSVC_SUPPRESS_WARNING_POP
-
 } // namespace detail
 namespace {
     using namespace detail;
 
-    std::ostream& file_line_to_stream(std::ostream& s, const char* file, int line,
-                                      const char* tail = "") {
-        const auto opt = getContextOptions();
-        s << Color::LightGrey << skipPathFromFilename(file) << (opt->gnu_file_line ? ":" : "(")
-          << (opt->no_line_numbers ? 0 : line) // 0 or the real num depending on the option
-          << (opt->gnu_file_line ? ":" : "):") << tail;
-        return s;
-    }
-
 #if !defined(DOCTEST_CONFIG_POSIX_SIGNALS) && !defined(DOCTEST_CONFIG_WINDOWS_SEH)
     struct FatalConditionHandler
     {
-        void reset() {}
+        static void reset() {}
+        static void allocateAltStackMem() {}
+        static void freeAltStackMem() {}
     };
 #else // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
 
@@ -3961,43 +4584,113 @@ namespace {
     // Windows can easily distinguish between SO and SigSegV,
     // but SigInt, SigTerm, etc are handled differently.
     SignalDefs signalDefs[] = {
-            {EXCEPTION_ILLEGAL_INSTRUCTION, "SIGILL - Illegal instruction signal"},
-            {EXCEPTION_STACK_OVERFLOW, "SIGSEGV - Stack overflow"},
-            {EXCEPTION_ACCESS_VIOLATION, "SIGSEGV - Segmentation violation signal"},
-            {EXCEPTION_INT_DIVIDE_BY_ZERO, "Divide by zero error"},
+            {static_cast<DWORD>(EXCEPTION_ILLEGAL_INSTRUCTION),
+             "SIGILL - Illegal instruction signal"},
+            {static_cast<DWORD>(EXCEPTION_STACK_OVERFLOW), "SIGSEGV - Stack overflow"},
+            {static_cast<DWORD>(EXCEPTION_ACCESS_VIOLATION),
+             "SIGSEGV - Segmentation violation signal"},
+            {static_cast<DWORD>(EXCEPTION_INT_DIVIDE_BY_ZERO), "Divide by zero error"},
     };
 
     struct FatalConditionHandler
     {
-        static LONG CALLBACK handleVectoredException(PEXCEPTION_POINTERS ExceptionInfo) {
-            for(size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
-                if(ExceptionInfo->ExceptionRecord->ExceptionCode == signalDefs[i].id) {
-                    reportFatal(signalDefs[i].name);
+        static LONG CALLBACK handleException(PEXCEPTION_POINTERS ExceptionInfo) {
+            // Multiple threads may enter this filter/handler at once. We want the error message to be printed on the
+            // console just once no matter how many threads have crashed.
+            DOCTEST_DECLARE_STATIC_MUTEX(mutex)
+            static bool execute = true;
+            {
+                DOCTEST_LOCK_MUTEX(mutex)
+                if(execute) {
+                    bool reported = false;
+                    for(size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
+                        if(ExceptionInfo->ExceptionRecord->ExceptionCode == signalDefs[i].id) {
+                            reportFatal(signalDefs[i].name);
+                            reported = true;
+                            break;
+                        }
+                    }
+                    if(reported == false)
+                        reportFatal("Unhandled SEH exception caught");
+                    if(isDebuggerActive() && !g_cs->no_breaks)
+                        DOCTEST_BREAK_INTO_DEBUGGER();
                 }
+                execute = false;
             }
-            // If its not an exception we care about, pass it along.
-            // This stops us from eating debugger breaks etc.
-            return EXCEPTION_CONTINUE_SEARCH;
+            std::exit(EXIT_FAILURE);
         }
+
+        static void allocateAltStackMem() {}
+        static void freeAltStackMem() {}
 
         FatalConditionHandler() {
             isSet = true;
             // 32k seems enough for doctest to handle stack overflow,
             // but the value was found experimentally, so there is no strong guarantee
             guaranteeSize = 32 * 1024;
-            exceptionHandlerHandle = nullptr;
-            // Register as first handler in current chain
-            exceptionHandlerHandle = AddVectoredExceptionHandler(1, handleVectoredException);
+            // Register an unhandled exception filter
+            previousTop = SetUnhandledExceptionFilter(handleException);
             // Pass in guarantee size to be filled
             SetThreadStackGuarantee(&guaranteeSize);
+
+            // On Windows uncaught exceptions from another thread, exceptions from
+            // destructors, or calls to std::terminate are not a SEH exception
+
+            // The terminal handler gets called when:
+            // - std::terminate is called FROM THE TEST RUNNER THREAD
+            // - an exception is thrown from a destructor FROM THE TEST RUNNER THREAD
+            original_terminate_handler = std::get_terminate();
+            std::set_terminate([]() DOCTEST_NOEXCEPT {
+                reportFatal("Terminate handler called");
+                if(isDebuggerActive() && !g_cs->no_breaks)
+                    DOCTEST_BREAK_INTO_DEBUGGER();
+                std::exit(EXIT_FAILURE); // explicitly exit - otherwise the SIGABRT handler may be called as well
+            });
+
+            // SIGABRT is raised when:
+            // - std::terminate is called FROM A DIFFERENT THREAD
+            // - an exception is thrown from a destructor FROM A DIFFERENT THREAD
+            // - an uncaught exception is thrown FROM A DIFFERENT THREAD
+            prev_sigabrt_handler = std::signal(SIGABRT, [](int signal) DOCTEST_NOEXCEPT {
+                if(signal == SIGABRT) {
+                    reportFatal("SIGABRT - Abort (abnormal termination) signal");
+                    if(isDebuggerActive() && !g_cs->no_breaks)
+                        DOCTEST_BREAK_INTO_DEBUGGER();
+                    std::exit(EXIT_FAILURE);
+                }
+            });
+
+            // The following settings are taken from google test, and more
+            // specifically from UnitTest::Run() inside of gtest.cc
+
+            // the user does not want to see pop-up dialogs about crashes
+            prev_error_mode_1 = SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOALIGNMENTFAULTEXCEPT |
+                                             SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
+            // This forces the abort message to go to stderr in all circumstances.
+            prev_error_mode_2 = _set_error_mode(_OUT_TO_STDERR);
+            // In the debug version, Visual Studio pops up a separate dialog
+            // offering a choice to debug the aborted program - we want to disable that.
+            prev_abort_behavior = _set_abort_behavior(0x0, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+            // In debug mode, the Windows CRT can crash with an assertion over invalid
+            // input (e.g. passing an invalid file descriptor). The default handling
+            // for these assertions is to pop up a dialog and wait for user input.
+            // Instead ask the CRT to dump such assertions to stderr non-interactively.
+            prev_report_mode = _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_FILE | _CRTDBG_MODE_DEBUG);
+            prev_report_file = _CrtSetReportFile(_CRT_ASSERT, _CRTDBG_FILE_STDERR);
         }
 
         static void reset() {
             if(isSet) {
                 // Unregister handler and restore the old guarantee
-                RemoveVectoredExceptionHandler(exceptionHandlerHandle);
+                SetUnhandledExceptionFilter(previousTop);
                 SetThreadStackGuarantee(&guaranteeSize);
-                exceptionHandlerHandle = nullptr;
+                std::set_terminate(original_terminate_handler);
+                std::signal(SIGABRT, prev_sigabrt_handler);
+                SetErrorMode(prev_error_mode_1);
+                _set_error_mode(prev_error_mode_2);
+                _set_abort_behavior(prev_abort_behavior, _WRITE_ABORT_MSG | _CALL_REPORTFAULT);
+                static_cast<void>(_CrtSetReportMode(_CRT_ASSERT, prev_report_mode));
+                static_cast<void>(_CrtSetReportFile(_CRT_ASSERT, prev_report_file));
                 isSet = false;
             }
         }
@@ -4005,14 +4698,28 @@ namespace {
         ~FatalConditionHandler() { reset(); }
 
     private:
+        static UINT         prev_error_mode_1;
+        static int          prev_error_mode_2;
+        static unsigned int prev_abort_behavior;
+        static int          prev_report_mode;
+        static _HFILE       prev_report_file;
+        static void (DOCTEST_CDECL *prev_sigabrt_handler)(int);
+        static std::terminate_handler original_terminate_handler;
         static bool isSet;
         static ULONG guaranteeSize;
-        static PVOID exceptionHandlerHandle;
+        static LPTOP_LEVEL_EXCEPTION_FILTER previousTop;
     };
 
+    UINT         FatalConditionHandler::prev_error_mode_1;
+    int          FatalConditionHandler::prev_error_mode_2;
+    unsigned int FatalConditionHandler::prev_abort_behavior;
+    int          FatalConditionHandler::prev_report_mode;
+    _HFILE       FatalConditionHandler::prev_report_file;
+    void (DOCTEST_CDECL *FatalConditionHandler::prev_sigabrt_handler)(int);
+    std::terminate_handler FatalConditionHandler::original_terminate_handler;
     bool FatalConditionHandler::isSet = false;
     ULONG FatalConditionHandler::guaranteeSize = 0;
-    PVOID FatalConditionHandler::exceptionHandlerHandle = nullptr;
+    LPTOP_LEVEL_EXCEPTION_FILTER FatalConditionHandler::previousTop = nullptr;
 
 #else // DOCTEST_PLATFORM_WINDOWS
 
@@ -4033,7 +4740,8 @@ namespace {
         static bool             isSet;
         static struct sigaction oldSigActions[DOCTEST_COUNTOF(signalDefs)];
         static stack_t          oldSigStack;
-        static char             altStackMem[4 * SIGSTKSZ];
+        static size_t           altStackSize;
+        static char*            altStackMem;
 
         static void handleSignal(int sig) {
             const char* name = "<unknown signal>";
@@ -4049,15 +4757,23 @@ namespace {
             raise(sig);
         }
 
+        static void allocateAltStackMem() {
+            altStackMem = new char[altStackSize];
+        }
+
+        static void freeAltStackMem() {
+            delete[] altStackMem;
+        }
+
         FatalConditionHandler() {
             isSet = true;
             stack_t sigStack;
             sigStack.ss_sp    = altStackMem;
-            sigStack.ss_size  = sizeof(altStackMem);
+            sigStack.ss_size  = altStackSize;
             sigStack.ss_flags = 0;
             sigaltstack(&sigStack, &oldSigStack);
             struct sigaction sa = {};
-            sa.sa_handler       = handleSignal; // NOLINT
+            sa.sa_handler       = handleSignal;
             sa.sa_flags         = SA_ONSTACK;
             for(std::size_t i = 0; i < DOCTEST_COUNTOF(signalDefs); ++i) {
                 sigaction(signalDefs[i].id, &sa, &oldSigActions[i]);
@@ -4078,10 +4794,11 @@ namespace {
         }
     };
 
-    bool             FatalConditionHandler::isSet                                      = false;
+    bool             FatalConditionHandler::isSet = false;
     struct sigaction FatalConditionHandler::oldSigActions[DOCTEST_COUNTOF(signalDefs)] = {};
-    stack_t          FatalConditionHandler::oldSigStack                                = {};
-    char             FatalConditionHandler::altStackMem[]                              = {};
+    stack_t          FatalConditionHandler::oldSigStack = {};
+    size_t           FatalConditionHandler::altStackSize = 4 * SIGSTKSZ;
+    char*            FatalConditionHandler::altStackMem = nullptr;
 
 #endif // DOCTEST_PLATFORM_WINDOWS
 #endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
@@ -4095,7 +4812,7 @@ namespace {
 #define DOCTEST_OUTPUT_DEBUG_STRING(text) ::OutputDebugStringA(text)
 #else
     // TODO: integration with XCode and other IDEs
-#define DOCTEST_OUTPUT_DEBUG_STRING(text) // NOLINT(clang-diagnostic-unused-macros)
+#define DOCTEST_OUTPUT_DEBUG_STRING(text)
 #endif // Platform
 
     void addAssert(assertType::Enum at) {
@@ -4114,8 +4831,10 @@ namespace {
 
         DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_exception, {message.c_str(), true});
 
-        while(g_cs->subcasesCurrentLevel--)
+        while (g_cs->subcaseStack.size()) {
+            g_cs->subcaseStack.pop_back();
             DOCTEST_ITERATE_THROUGH_REPORTERS(subcase_end, DOCTEST_EMPTY);
+        }
 
         g_cs->finalizeTestCaseData();
 
@@ -4125,26 +4844,26 @@ namespace {
     }
 #endif // DOCTEST_CONFIG_POSIX_SIGNALS || DOCTEST_CONFIG_WINDOWS_SEH
 } // namespace
+
+AssertData::AssertData(assertType::Enum at, const char* file, int line, const char* expr,
+    const char* exception_type, const StringContains& exception_string)
+    : m_test_case(g_cs->currentTest), m_at(at), m_file(file), m_line(line), m_expr(expr),
+    m_failed(true), m_threw(false), m_threw_as(false), m_exception_type(exception_type),
+    m_exception_string(exception_string) {
+#if DOCTEST_MSVC
+    if (m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
+        ++m_expr;
+#endif // MSVC
+}
+
 namespace detail {
+    ResultBuilder::ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
+                                 const char* exception_type, const String& exception_string)
+        : AssertData(at, file, line, expr, exception_type, exception_string) { }
 
     ResultBuilder::ResultBuilder(assertType::Enum at, const char* file, int line, const char* expr,
-                                 const char* exception_type) {
-        m_test_case      = g_cs->currentTest;
-        m_at             = at;
-        m_file           = file;
-        m_line           = line;
-        m_expr           = expr;
-        m_failed         = true;
-        m_threw          = false;
-        m_threw_as       = false;
-        m_exception_type = exception_type;
-#if DOCTEST_MSVC
-        if(m_expr[0] == ' ') // this happens when variadic macros are disabled under MSVC
-            ++m_expr;
-#endif // MSVC
-    }
-
-    DOCTEST_DEFINE_DEFAULTS(ResultBuilder);
+        const char* exception_type, const Contains& exception_string)
+        : AssertData(at, file, line, expr, exception_type, exception_string) { }
 
     void ResultBuilder::setResult(const Result& res) {
         m_decomp = res.m_decomp;
@@ -4159,16 +4878,18 @@ namespace detail {
     bool ResultBuilder::log() {
         if(m_at & assertType::is_throws) { //!OCLINT bitwise operator in conditional
             m_failed = !m_threw;
+        } else if((m_at & assertType::is_throws_as) && (m_at & assertType::is_throws_with)) { //!OCLINT
+            m_failed = !m_threw_as || !m_exception_string.check(m_exception);
         } else if(m_at & assertType::is_throws_as) { //!OCLINT bitwise operator in conditional
             m_failed = !m_threw_as;
         } else if(m_at & assertType::is_throws_with) { //!OCLINT bitwise operator in conditional
-            m_failed = m_exception != m_exception_type;
+            m_failed = !m_exception_string.check(m_exception);
         } else if(m_at & assertType::is_nothrow) { //!OCLINT bitwise operator in conditional
             m_failed = m_threw;
         }
 
         if(m_exception.size())
-            m_exception = String("\"") + m_exception + "\"";
+            m_exception = "\"" + m_exception + "\"";
 
         if(is_running_in_test) {
             addAssert(m_at);
@@ -4180,8 +4901,8 @@ namespace detail {
             failed_out_of_a_testing_context(*this);
         }
 
-        return m_failed && isDebuggerActive() &&
-               !getContextOptions()->no_breaks; // break into debugger
+        return m_failed && isDebuggerActive() && !getContextOptions()->no_breaks &&
+            (g_cs->currentTest == nullptr || !g_cs->currentTest->m_no_breaks); // break into debugger
     }
 
     void ResultBuilder::react() const {
@@ -4196,8 +4917,8 @@ namespace detail {
             std::abort();
     }
 
-    void decomp_assert(assertType::Enum at, const char* file, int line, const char* expr,
-                       Result result) {
+    bool decomp_assert(assertType::Enum at, const char* file, int line, const char* expr,
+                       const Result& result) {
         bool failed = !result.m_passed;
 
         // ###################################################################################
@@ -4206,57 +4927,50 @@ namespace detail {
         // ###################################################################################
         DOCTEST_ASSERT_OUT_OF_TESTS(result.m_decomp);
         DOCTEST_ASSERT_IN_TESTS(result.m_decomp);
+        return !failed;
     }
 
     MessageBuilder::MessageBuilder(const char* file, int line, assertType::Enum severity) {
-        m_stream   = getTlsOss();
+        m_stream   = tlssPush();
         m_file     = file;
         m_line     = line;
         m_severity = severity;
     }
 
-    IExceptionTranslator::IExceptionTranslator()  = default;
-    IExceptionTranslator::~IExceptionTranslator() = default;
+    MessageBuilder::~MessageBuilder() {
+        if (!logged)
+            tlssPop();
+    }
+
+    DOCTEST_DEFINE_INTERFACE(IExceptionTranslator)
 
     bool MessageBuilder::log() {
-        m_string = getTlsOssResult();
+        if (!logged) {
+            m_string = tlssPop();
+            logged = true;
+        }
+        
         DOCTEST_ITERATE_THROUGH_REPORTERS(log_message, *this);
 
         const bool isWarn = m_severity & assertType::is_warn;
 
-        // warn is just a message in this context so we dont treat it as an assert
+        // warn is just a message in this context so we don't treat it as an assert
         if(!isWarn) {
             addAssert(m_severity);
             addFailedAssert(m_severity);
         }
 
-        return isDebuggerActive() && !getContextOptions()->no_breaks && !isWarn; // break
+        return isDebuggerActive() && !getContextOptions()->no_breaks && !isWarn &&
+            (g_cs->currentTest == nullptr || !g_cs->currentTest->m_no_breaks); // break into debugger
     }
 
     void MessageBuilder::react() {
         if(m_severity & assertType::is_require) //!OCLINT bitwise operator in conditional
             throwException();
     }
-
-    MessageBuilder::~MessageBuilder() = default;
 } // namespace detail
 namespace {
     using namespace detail;
-
-    template <typename Ex>
-    [[noreturn]] void throw_exception(Ex const& e) {
-#ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
-        throw e;
-#else  // DOCTEST_CONFIG_NO_EXCEPTIONS
-        std::cerr << "doctest will terminate because it needed to throw an exception.\n"
-                  << "The message was: " << e.what() << '\n';
-        std::terminate();
-#endif // DOCTEST_CONFIG_NO_EXCEPTIONS
-    }
-
-#define DOCTEST_INTERNAL_ERROR(msg)                                                                \
-    throw_exception(std::logic_error(                                                              \
-            __FILE__ ":" DOCTEST_TOSTR(__LINE__) ": Internal doctest error: " msg))
 
     // clang-format off
 
@@ -4287,8 +5001,8 @@ namespace {
         public:
             ScopedElement( XmlWriter* writer );
 
-            ScopedElement( ScopedElement&& other ) noexcept;
-            ScopedElement& operator=( ScopedElement&& other ) noexcept;
+            ScopedElement( ScopedElement&& other ) DOCTEST_NOEXCEPT;
+            ScopedElement& operator=( ScopedElement&& other ) DOCTEST_NOEXCEPT;
 
             ~ScopedElement();
 
@@ -4339,9 +5053,9 @@ namespace {
 
         void ensureTagClosed();
 
-    private:
-
         void writeDeclaration();
+
+    private:
 
         void newlineIfNecessary();
 
@@ -4404,7 +5118,7 @@ namespace {
 
     void XmlEncode::encodeTo( std::ostream& os ) const {
         // Apostrophe escaping not necessary if we always use " to write attributes
-        // (see: http://www.w3.org/TR/xml/#syntax)
+        // (see: https://www.w3.org/TR/xml/#syntax)
 
         for( std::size_t idx = 0; idx < m_str.size(); ++ idx ) {
             uchar c = m_str[idx];
@@ -4413,7 +5127,7 @@ namespace {
             case '&':   os << "&amp;"; break;
 
             case '>':
-                // See: http://www.w3.org/TR/xml/#syntax
+                // See: https://www.w3.org/TR/xml/#syntax
                 if (idx > 2 && m_str[idx - 1] == ']' && m_str[idx - 2] == ']')
                     os << "&gt;";
                 else
@@ -4431,7 +5145,7 @@ namespace {
                 // Check for control characters and invalid utf-8
 
                 // Escape control characters in standard ascii
-                // see http://stackoverflow.com/questions/404107/why-are-control-characters-illegal-in-xml-1-0
+                // see https://stackoverflow.com/questions/404107/why-are-control-characters-illegal-in-xml-1-0
                 if (c < 0x09 || (c > 0x0D && c < 0x20) || c == 0x7F) {
                     hexEscapeChar(os, c);
                     break;
@@ -4505,11 +5219,11 @@ namespace {
     :   m_writer( writer )
     {}
 
-    XmlWriter::ScopedElement::ScopedElement( ScopedElement&& other ) noexcept
+    XmlWriter::ScopedElement::ScopedElement( ScopedElement&& other ) DOCTEST_NOEXCEPT
     :   m_writer( other.m_writer ){
         other.m_writer = nullptr;
     }
-    XmlWriter::ScopedElement& XmlWriter::ScopedElement::operator=( ScopedElement&& other ) noexcept {
+    XmlWriter::ScopedElement& XmlWriter::ScopedElement::operator=( ScopedElement&& other ) DOCTEST_NOEXCEPT {
         if ( m_writer ) {
             m_writer->endElement();
         }
@@ -4531,7 +5245,7 @@ namespace {
 
     XmlWriter::XmlWriter( std::ostream& os ) : m_os( os )
     {
-        writeDeclaration();
+        // writeDeclaration(); // called explicitly by the reporters that use the writer class - see issue #627
     }
 
     XmlWriter::~XmlWriter() {
@@ -4642,8 +5356,8 @@ namespace {
 
     struct XmlReporter : public IReporter
     {
-        XmlWriter  xml;
-        std::mutex mutex;
+        XmlWriter xml;
+        DOCTEST_DECLARE_MUTEX(mutex)
 
         // caching pointers/references to objects of these types - safe to do
         const ContextOptions& opt;
@@ -4671,7 +5385,7 @@ namespace {
         void test_case_start_impl(const TestCaseData& in) {
             bool open_ts_tag = false;
             if(tc != nullptr) { // we have already opened a test suite
-                if(strcmp(tc->m_test_suite, in.m_test_suite) != 0) {
+                if(std::strcmp(tc->m_test_suite, in.m_test_suite) != 0) {
                     xml.endElement();
                     open_ts_tag = true;
                 }
@@ -4688,7 +5402,7 @@ namespace {
             tc = &in;
             xml.startElement("TestCase")
                     .writeAttribute("name", in.m_name)
-                    .writeAttribute("filename", skipPathFromFilename(in.m_file))
+                    .writeAttribute("filename", skipPathFromFilename(in.m_file.c_str()))
                     .writeAttribute("line", line(in.m_line))
                     .writeAttribute("description", in.m_description);
 
@@ -4716,13 +5430,18 @@ namespace {
                             .writeAttribute("priority", curr.first.first)
                             .writeAttribute("name", curr.first.second);
             } else if(opt.count || opt.list_test_cases) {
-                for(unsigned i = 0; i < in.num_data; ++i)
-                    xml.scopedElement("TestCase").writeAttribute("name", in.data[i]);
+                for(unsigned i = 0; i < in.num_data; ++i) {
+                    xml.scopedElement("TestCase").writeAttribute("name", in.data[i]->m_name)
+                        .writeAttribute("testsuite", in.data[i]->m_test_suite)
+                        .writeAttribute("filename", skipPathFromFilename(in.data[i]->m_file.c_str()))
+                        .writeAttribute("line", line(in.data[i]->m_line))
+                        .writeAttribute("skipped", in.data[i]->m_skip);
+                }
                 xml.scopedElement("OverallResultsTestCases")
                         .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
             } else if(opt.list_test_suites) {
                 for(unsigned i = 0; i < in.num_data; ++i)
-                    xml.scopedElement("TestSuite").writeAttribute("name", in.data[i]);
+                    xml.scopedElement("TestSuite").writeAttribute("name", in.data[i]->m_test_suite);
                 xml.scopedElement("OverallResultsTestCases")
                         .writeAttribute("unskipped", in.run_stats->numTestCasesPassingFilters);
                 xml.scopedElement("OverallResultsTestSuites")
@@ -4732,6 +5451,8 @@ namespace {
         }
 
         void test_run_start() override {
+            xml.writeDeclaration();
+
             // remove .exe extension - mainly to have the same output on UNIX and Windows
             std::string binary_name = skipPathFromFilename(opt.binary_name.c_str());
 #ifdef DOCTEST_PLATFORM_WINDOWS
@@ -4779,12 +5500,15 @@ namespace {
             test_case_start_impl(in);
             xml.ensureTagClosed();
         }
+        
+        void test_case_reenter(const TestCaseData&) override {}
 
         void test_case_end(const CurrentTestCaseStats& st) override {
             xml.startElement("OverallResultsAsserts")
                     .writeAttribute("successes",
                                     st.numAssertsCurrentTest - st.numAssertsFailedCurrentTest)
-                    .writeAttribute("failures", st.numAssertsFailedCurrentTest);
+                    .writeAttribute("failures", st.numAssertsFailedCurrentTest)
+                    .writeAttribute("test_case_success", st.testCaseSuccess);
             if(opt.duration)
                 xml.writeAttribute("duration", st.seconds);
             if(tc->m_expected_failures)
@@ -4795,7 +5519,7 @@ namespace {
         }
 
         void test_case_exception(const TestCaseException& e) override {
-            std::lock_guard<std::mutex> lock(mutex);
+            DOCTEST_LOCK_MUTEX(mutex)
 
             xml.scopedElement("Exception")
                     .writeAttribute("crash", e.is_crash)
@@ -4803,8 +5527,6 @@ namespace {
         }
 
         void subcase_start(const SubcaseSignature& in) override {
-            std::lock_guard<std::mutex> lock(mutex);
-
             xml.startElement("SubCase")
                     .writeAttribute("name", in.m_name)
                     .writeAttribute("filename", skipPathFromFilename(in.m_file))
@@ -4818,7 +5540,7 @@ namespace {
             if(!rb.m_failed && !opt.success)
                 return;
 
-            std::lock_guard<std::mutex> lock(mutex);
+            DOCTEST_LOCK_MUTEX(mutex)
 
             xml.startElement("Expression")
                     .writeAttribute("success", !rb.m_failed)
@@ -4831,11 +5553,12 @@ namespace {
             if(rb.m_threw)
                 xml.scopedElement("Exception").writeText(rb.m_exception.c_str());
 
-            if(rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) {
+            if(rb.m_at & assertType::is_throws_as)
                 xml.scopedElement("ExpectedException").writeText(rb.m_exception_type);
-            } else if((rb.m_at & assertType::is_normal) && !rb.m_threw) {
+            if(rb.m_at & assertType::is_throws_with)
+                xml.scopedElement("ExpectedExceptionString").writeText(rb.m_exception_string.c_str());
+            if((rb.m_at & assertType::is_normal) && !rb.m_threw)
                 xml.scopedElement("Expanded").writeText(rb.m_decomp.c_str());
-            }
 
             log_contexts();
 
@@ -4843,7 +5566,7 @@ namespace {
         }
 
         void log_message(const MessageData& mb) override {
-            std::lock_guard<std::mutex> lock(mutex);
+            DOCTEST_LOCK_MUTEX(mutex)
 
             xml.startElement("Message")
                     .writeAttribute("type", failureString(mb.m_severity))
@@ -4868,6 +5591,284 @@ namespace {
 
     DOCTEST_REGISTER_REPORTER("xml", 0, XmlReporter);
 
+    void fulltext_log_assert_to_stream(std::ostream& s, const AssertData& rb) {
+        if((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) ==
+            0) //!OCLINT bitwise operator in conditional
+            s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << " ) "
+                << Color::None;
+
+        if(rb.m_at & assertType::is_throws) { //!OCLINT bitwise operator in conditional
+            s << (rb.m_threw ? "threw as expected!" : "did NOT throw at all!") << "\n";
+        } else if((rb.m_at & assertType::is_throws_as) &&
+                    (rb.m_at & assertType::is_throws_with)) { //!OCLINT
+            s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
+                << rb.m_exception_string.c_str()
+                << "\", " << rb.m_exception_type << " ) " << Color::None;
+            if(rb.m_threw) {
+                if(!rb.m_failed) {
+                    s << "threw as expected!\n";
+                } else {
+                    s << "threw a DIFFERENT exception! (contents: " << rb.m_exception << ")\n";
+                }
+            } else {
+                s << "did NOT throw at all!\n";
+            }
+        } else if(rb.m_at &
+                    assertType::is_throws_as) { //!OCLINT bitwise operator in conditional
+            s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", "
+                << rb.m_exception_type << " ) " << Color::None
+                << (rb.m_threw ? (rb.m_threw_as ? "threw as expected!" :
+                                                "threw a DIFFERENT exception: ") :
+                                "did NOT throw at all!")
+                << Color::Cyan << rb.m_exception << "\n";
+        } else if(rb.m_at &
+                    assertType::is_throws_with) { //!OCLINT bitwise operator in conditional
+            s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
+                << rb.m_exception_string.c_str()
+                << "\" ) " << Color::None
+                << (rb.m_threw ? (!rb.m_failed ? "threw as expected!" :
+                                                "threw a DIFFERENT exception: ") :
+                                "did NOT throw at all!")
+                << Color::Cyan << rb.m_exception << "\n";
+        } else if(rb.m_at & assertType::is_nothrow) { //!OCLINT bitwise operator in conditional
+            s << (rb.m_threw ? "THREW exception: " : "didn't throw!") << Color::Cyan
+                << rb.m_exception << "\n";
+        } else {
+            s << (rb.m_threw ? "THREW exception: " :
+                                (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n"));
+            if(rb.m_threw)
+                s << rb.m_exception << "\n";
+            else
+                s << "  values: " << assertString(rb.m_at) << "( " << rb.m_decomp << " )\n";
+        }
+    }
+
+    // TODO:
+    // - log_message()
+    // - respond to queries
+    // - honor remaining options
+    // - more attributes in tags
+    struct JUnitReporter : public IReporter
+    {
+        XmlWriter xml;
+        DOCTEST_DECLARE_MUTEX(mutex)
+        Timer timer;
+        std::vector<String> deepestSubcaseStackNames;
+
+        struct JUnitTestCaseData
+        {
+            static std::string getCurrentTimestamp() {
+                // Beware, this is not reentrant because of backward compatibility issues
+                // Also, UTC only, again because of backward compatibility (%z is C++11)
+                time_t rawtime;
+                std::time(&rawtime);
+                auto const timeStampSize = sizeof("2017-01-16T17:06:45Z");
+
+                std::tm timeInfo;
+#ifdef DOCTEST_PLATFORM_WINDOWS
+                gmtime_s(&timeInfo, &rawtime);
+#else // DOCTEST_PLATFORM_WINDOWS
+                gmtime_r(&rawtime, &timeInfo);
+#endif // DOCTEST_PLATFORM_WINDOWS
+
+                char timeStamp[timeStampSize];
+                const char* const fmt = "%Y-%m-%dT%H:%M:%SZ";
+
+                std::strftime(timeStamp, timeStampSize, fmt, &timeInfo);
+                return std::string(timeStamp);
+            }
+
+            struct JUnitTestMessage
+            {
+                JUnitTestMessage(const std::string& _message, const std::string& _type, const std::string& _details)
+                    : message(_message), type(_type), details(_details) {}
+
+                JUnitTestMessage(const std::string& _message, const std::string& _details)
+                    : message(_message), type(), details(_details) {}
+
+                std::string message, type, details;
+            };
+
+            struct JUnitTestCase
+            {
+                JUnitTestCase(const std::string& _classname, const std::string& _name)
+                    : classname(_classname), name(_name), time(0), failures() {}
+
+                std::string classname, name;
+                double time;
+                std::vector<JUnitTestMessage> failures, errors;
+            };
+
+            void add(const std::string& classname, const std::string& name) {
+                testcases.emplace_back(classname, name);
+            }
+
+            void appendSubcaseNamesToLastTestcase(std::vector<String> nameStack) {
+                for(auto& curr: nameStack)
+                    if(curr.size())
+                        testcases.back().name += std::string("/") + curr.c_str();
+            }
+
+            void addTime(double time) {
+                if(time < 1e-4)
+                    time = 0;
+                testcases.back().time = time;
+                totalSeconds += time;
+            }
+
+            void addFailure(const std::string& message, const std::string& type, const std::string& details) {
+                testcases.back().failures.emplace_back(message, type, details);
+                ++totalFailures;
+            }
+
+            void addError(const std::string& message, const std::string& details) {
+                testcases.back().errors.emplace_back(message, details);
+                ++totalErrors;
+            }
+
+            std::vector<JUnitTestCase> testcases;
+            double totalSeconds = 0;
+            int totalErrors = 0, totalFailures = 0;
+        };
+
+        JUnitTestCaseData testCaseData;
+
+        // caching pointers/references to objects of these types - safe to do
+        const ContextOptions& opt;
+        const TestCaseData*   tc = nullptr;
+
+        JUnitReporter(const ContextOptions& co)
+                : xml(*co.cout)
+                , opt(co) {}
+
+        unsigned line(unsigned l) const { return opt.no_line_numbers ? 0 : l; }
+
+        // =========================================================================================
+        // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
+        // =========================================================================================
+
+        void report_query(const QueryData&) override {
+            xml.writeDeclaration();
+        }
+
+        void test_run_start() override {
+            xml.writeDeclaration();
+        }
+
+        void test_run_end(const TestRunStats& p) override {
+            // remove .exe extension - mainly to have the same output on UNIX and Windows
+            std::string binary_name = skipPathFromFilename(opt.binary_name.c_str());
+#ifdef DOCTEST_PLATFORM_WINDOWS
+            if(binary_name.rfind(".exe") != std::string::npos)
+                binary_name = binary_name.substr(0, binary_name.length() - 4);
+#endif // DOCTEST_PLATFORM_WINDOWS
+            xml.startElement("testsuites");
+            xml.startElement("testsuite").writeAttribute("name", binary_name)
+                    .writeAttribute("errors", testCaseData.totalErrors)
+                    .writeAttribute("failures", testCaseData.totalFailures)
+                    .writeAttribute("tests", p.numAsserts);
+            if(opt.no_time_in_output == false) {
+                xml.writeAttribute("time", testCaseData.totalSeconds);
+                xml.writeAttribute("timestamp", JUnitTestCaseData::getCurrentTimestamp());
+            }
+            if(opt.no_version == false)
+                xml.writeAttribute("doctest_version", DOCTEST_VERSION_STR);
+
+            for(const auto& testCase : testCaseData.testcases) {
+                xml.startElement("testcase")
+                    .writeAttribute("classname", testCase.classname)
+                    .writeAttribute("name", testCase.name);
+                if(opt.no_time_in_output == false)
+                    xml.writeAttribute("time", testCase.time);
+                // This is not ideal, but it should be enough to mimic gtest's junit output.
+                xml.writeAttribute("status", "run");
+
+                for(const auto& failure : testCase.failures) {
+                    xml.scopedElement("failure")
+                        .writeAttribute("message", failure.message)
+                        .writeAttribute("type", failure.type)
+                        .writeText(failure.details, false);
+                }
+
+                for(const auto& error : testCase.errors) {
+                    xml.scopedElement("error")
+                        .writeAttribute("message", error.message)
+                        .writeText(error.details);
+                }
+
+                xml.endElement();
+            }
+            xml.endElement();
+            xml.endElement();
+        }
+
+        void test_case_start(const TestCaseData& in) override {
+            testCaseData.add(skipPathFromFilename(in.m_file.c_str()), in.m_name);
+            timer.start();
+        }
+
+        void test_case_reenter(const TestCaseData& in) override {
+            testCaseData.addTime(timer.getElapsedSeconds());
+            testCaseData.appendSubcaseNamesToLastTestcase(deepestSubcaseStackNames);
+            deepestSubcaseStackNames.clear();
+
+            timer.start();
+            testCaseData.add(skipPathFromFilename(in.m_file.c_str()), in.m_name);
+        }
+
+        void test_case_end(const CurrentTestCaseStats&) override {
+            testCaseData.addTime(timer.getElapsedSeconds());
+            testCaseData.appendSubcaseNamesToLastTestcase(deepestSubcaseStackNames);
+            deepestSubcaseStackNames.clear();
+        }
+
+        void test_case_exception(const TestCaseException& e) override {
+            DOCTEST_LOCK_MUTEX(mutex)
+            testCaseData.addError("exception", e.error_string.c_str());
+        }
+
+        void subcase_start(const SubcaseSignature& in) override {
+            deepestSubcaseStackNames.push_back(in.m_name);
+        }
+
+        void subcase_end() override {}
+
+        void log_assert(const AssertData& rb) override {
+            if(!rb.m_failed) // report only failures & ignore the `success` option
+                return;
+
+            DOCTEST_LOCK_MUTEX(mutex)
+
+            std::ostringstream os;
+            os << skipPathFromFilename(rb.m_file) << (opt.gnu_file_line ? ":" : "(")
+              << line(rb.m_line) << (opt.gnu_file_line ? ":" : "):") << std::endl;
+
+            fulltext_log_assert_to_stream(os, rb);
+            log_contexts(os);
+            testCaseData.addFailure(rb.m_decomp.c_str(), assertString(rb.m_at), os.str());
+        }
+
+        void log_message(const MessageData&) override {}
+
+        void test_case_skipped(const TestCaseData&) override {}
+
+        void log_contexts(std::ostringstream& s) {
+            int num_contexts = get_num_active_contexts();
+            if(num_contexts) {
+                auto contexts = get_active_contexts();
+
+                s << "  logged: ";
+                for(int i = 0; i < num_contexts; ++i) {
+                    s << (i == 0 ? "" : "          ");
+                    contexts[i]->stringify(&s);
+                    s << std::endl;
+                }
+            }
+        }
+    };
+
+    DOCTEST_REGISTER_REPORTER("junit", 0, JUnitReporter);
+
     struct Whitespace
     {
         int nrSpaces;
@@ -4886,7 +5887,8 @@ namespace {
         std::ostream&                 s;
         bool                          hasLoggedCurrentTestStart;
         std::vector<SubcaseSignature> subcasesStack;
-        std::mutex                    mutex;
+        size_t                        currentSubcaseLevel;
+        DOCTEST_DECLARE_MUTEX(mutex)
 
         // caching pointers/references to objects of these types - safe to do
         const ContextOptions& opt;
@@ -4944,23 +5946,40 @@ namespace {
             s << "\n";
         }
 
+        // this was requested to be made virtual so users could override it
+        virtual void file_line_to_stream(const char* file, int line,
+                                        const char* tail = "") {
+            s << Color::LightGrey << skipPathFromFilename(file) << (opt.gnu_file_line ? ":" : "(")
+            << (opt.no_line_numbers ? 0 : line) // 0 or the real num depending on the option
+            << (opt.gnu_file_line ? ":" : "):") << tail;
+        }
+
         void logTestStart() {
             if(hasLoggedCurrentTestStart)
                 return;
 
             separator_to_stream();
-            file_line_to_stream(s, tc->m_file, tc->m_line, "\n");
+            file_line_to_stream(tc->m_file.c_str(), tc->m_line, "\n");
             if(tc->m_description)
                 s << Color::Yellow << "DESCRIPTION: " << Color::None << tc->m_description << "\n";
             if(tc->m_test_suite && tc->m_test_suite[0] != '\0')
                 s << Color::Yellow << "TEST SUITE: " << Color::None << tc->m_test_suite << "\n";
             if(strncmp(tc->m_name, "  Scenario:", 11) != 0)
-                s << Color::None << "TEST CASE:  ";
+                s << Color::Yellow << "TEST CASE:  ";
             s << Color::None << tc->m_name << "\n";
 
-            for(auto& curr : subcasesStack)
-                if(curr.m_name[0] != '\0')
-                    s << "  " << curr.m_name << "\n";
+            for(size_t i = 0; i < currentSubcaseLevel; ++i) {
+                if(subcasesStack[i].m_name[0] != '\0')
+                    s << "  " << subcasesStack[i].m_name << "\n";
+            }
+
+            if(currentSubcaseLevel != subcasesStack.size()) {
+                s << Color::Yellow << "\nDEEPEST SUBCASE STACK REACHED (DIFFERENT FROM THE CURRENT ONE):\n" << Color::None;
+                for(size_t i = 0; i < subcasesStack.size(); ++i) {
+                    if(subcasesStack[i].m_name[0] != '\0')
+                        s << "  " << subcasesStack[i].m_name << "\n";
+                }
+            }
 
             s << "\n";
 
@@ -4974,9 +5993,11 @@ namespace {
         }
 
         void printIntro() {
-            printVersion();
-            s << Color::Cyan << "[doctest] " << Color::None
-              << "run with \"--" DOCTEST_OPTIONS_PREFIX_DISPLAY "help\" for options\n";
+            if(opt.no_intro == false) {
+                printVersion();
+                s << Color::Cyan << "[doctest] " << Color::None
+                  << "run with \"--" DOCTEST_OPTIONS_PREFIX_DISPLAY "help\" for options\n";
+            }
         }
 
         void printHelp() {
@@ -5038,7 +6059,7 @@ namespace {
               << Whitespace(sizePrefixDisplay*1) << "output filename\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ob,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "order-by=<string>             "
               << Whitespace(sizePrefixDisplay*1) << "how the tests should be ordered\n";
-            s << Whitespace(sizePrefixDisplay*3) << "                                       <string> - by [file/suite/name/rand]\n";
+            s << Whitespace(sizePrefixDisplay*3) << "                                       <string> - [file/suite/name/rand/none]\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "rs,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "rand-seed=<int>               "
               << Whitespace(sizePrefixDisplay*1) << "seed for random ordering\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "f,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "first=<int>                   "
@@ -5061,12 +6082,18 @@ namespace {
               << Whitespace(sizePrefixDisplay*1) << "exits after the tests finish\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "d,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "duration=<bool>               "
               << Whitespace(sizePrefixDisplay*1) << "prints the time duration of each test\n";
+            s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "m,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "minimal=<bool>                "
+              << Whitespace(sizePrefixDisplay*1) << "minimal console output (only failures)\n";
+            s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "q,   --" DOCTEST_OPTIONS_PREFIX_DISPLAY "quiet=<bool>                  "
+              << Whitespace(sizePrefixDisplay*1) << "no console output\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nt,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-throw=<bool>               "
               << Whitespace(sizePrefixDisplay*1) << "skips exceptions-related assert checks\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ne,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-exitcode=<bool>            "
               << Whitespace(sizePrefixDisplay*1) << "returns (or exits) always with success\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nr,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-run=<bool>                 "
               << Whitespace(sizePrefixDisplay*1) << "skips all runtime doctest operations\n";
+            s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "ni,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-intro=<bool>               "
+              << Whitespace(sizePrefixDisplay*1) << "omit the framework intro in the output\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nv,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-version=<bool>             "
               << Whitespace(sizePrefixDisplay*1) << "omit the framework version in the output\n";
             s << " -" DOCTEST_OPTIONS_PREFIX_DISPLAY "nc,  --" DOCTEST_OPTIONS_PREFIX_DISPLAY "no-colors=<bool>              "
@@ -5104,22 +6131,6 @@ namespace {
             printReporters(getReporters(), "reporters");
         }
 
-        void list_query_results() {
-            separator_to_stream();
-            if(opt.count || opt.list_test_cases) {
-                s << Color::Cyan << "[doctest] " << Color::None
-                  << "unskipped test cases passing the current filters: "
-                  << g_cs->numTestCasesPassingFilters << "\n";
-            } else if(opt.list_test_suites) {
-                s << Color::Cyan << "[doctest] " << Color::None
-                  << "unskipped test cases passing the current filters: "
-                  << g_cs->numTestCasesPassingFilters << "\n";
-                s << Color::Cyan << "[doctest] " << Color::None
-                  << "test suites with unskipped test cases passing the current filters: "
-                  << g_cs->numTestSuitesPassingFilters << "\n";
-            }
-        }
-
         // =========================================================================================
         // WHAT FOLLOWS ARE OVERRIDES OF THE VIRTUAL METHODS OF THE REPORTER INTERFACE
         // =========================================================================================
@@ -5139,7 +6150,7 @@ namespace {
                 }
 
                 for(unsigned i = 0; i < in.num_data; ++i)
-                    s << Color::None << in.data[i] << "\n";
+                    s << Color::None << in.data[i]->m_name << "\n";
 
                 separator_to_stream();
 
@@ -5152,7 +6163,7 @@ namespace {
                 separator_to_stream();
 
                 for(unsigned i = 0; i < in.num_data; ++i)
-                    s << Color::None << in.data[i] << "\n";
+                    s << Color::None << in.data[i]->m_test_suite << "\n";
 
                 separator_to_stream();
 
@@ -5165,30 +6176,40 @@ namespace {
             }
         }
 
-        void test_run_start() override { printIntro(); }
+        void test_run_start() override {
+            if(!opt.minimal)
+                printIntro();
+        }
 
         void test_run_end(const TestRunStats& p) override {
-            separator_to_stream();
+            if(opt.minimal && p.numTestCasesFailed == 0)
+                return;
 
+            separator_to_stream();
+            s << std::dec;
+
+            auto totwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters, static_cast<unsigned>(p.numAsserts))) + 1)));
+            auto passwidth = int(std::ceil(log10((std::max(p.numTestCasesPassingFilters - p.numTestCasesFailed, static_cast<unsigned>(p.numAsserts - p.numAssertsFailed))) + 1)));
+            auto failwidth = int(std::ceil(log10((std::max(p.numTestCasesFailed, static_cast<unsigned>(p.numAssertsFailed))) + 1)));
             const bool anythingFailed = p.numTestCasesFailed > 0 || p.numAssertsFailed > 0;
-            s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(6)
+            s << Color::Cyan << "[doctest] " << Color::None << "test cases: " << std::setw(totwidth)
               << p.numTestCasesPassingFilters << " | "
               << ((p.numTestCasesPassingFilters == 0 || anythingFailed) ? Color::None :
                                                                           Color::Green)
-              << std::setw(6) << p.numTestCasesPassingFilters - p.numTestCasesFailed << " passed"
+              << std::setw(passwidth) << p.numTestCasesPassingFilters - p.numTestCasesFailed << " passed"
               << Color::None << " | " << (p.numTestCasesFailed > 0 ? Color::Red : Color::None)
-              << std::setw(6) << p.numTestCasesFailed << " failed" << Color::None << " | ";
+              << std::setw(failwidth) << p.numTestCasesFailed << " failed" << Color::None << " |";
             if(opt.no_skipped_summary == false) {
                 const int numSkipped = p.numTestCases - p.numTestCasesPassingFilters;
-                s << (numSkipped == 0 ? Color::None : Color::Yellow) << std::setw(6) << numSkipped
+                s << " " << (numSkipped == 0 ? Color::None : Color::Yellow) << numSkipped
                   << " skipped" << Color::None;
             }
             s << "\n";
-            s << Color::Cyan << "[doctest] " << Color::None << "assertions: " << std::setw(6)
+            s << Color::Cyan << "[doctest] " << Color::None << "assertions: " << std::setw(totwidth)
               << p.numAsserts << " | "
               << ((p.numAsserts == 0 || anythingFailed) ? Color::None : Color::Green)
-              << std::setw(6) << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None
-              << " | " << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(6)
+              << std::setw(passwidth) << (p.numAsserts - p.numAssertsFailed) << " passed" << Color::None
+              << " | " << (p.numAssertsFailed > 0 ? Color::Red : Color::None) << std::setw(failwidth)
               << p.numAssertsFailed << " failed" << Color::None << " |\n";
             s << Color::Cyan << "[doctest] " << Color::None
               << "Status: " << (p.numTestCasesFailed > 0 ? Color::Red : Color::Green)
@@ -5198,13 +6219,22 @@ namespace {
         void test_case_start(const TestCaseData& in) override {
             hasLoggedCurrentTestStart = false;
             tc                        = &in;
+            subcasesStack.clear();
+            currentSubcaseLevel = 0;
+        }
+        
+        void test_case_reenter(const TestCaseData&) override {
+            subcasesStack.clear();
         }
 
         void test_case_end(const CurrentTestCaseStats& st) override {
+            if(tc->m_no_output)
+                return;
+
             // log the preamble of the test case only if there is something
             // else to print - something other than that an assert has failed
             if(opt.duration ||
-               (st.failure_flags && st.failure_flags != TestCaseFailureReason::AssertFailure))
+               (st.failure_flags && st.failure_flags != static_cast<int>(TestCaseFailureReason::AssertFailure)))
                 logTestStart();
 
             if(opt.duration)
@@ -5235,9 +6265,13 @@ namespace {
         }
 
         void test_case_exception(const TestCaseException& e) override {
+            DOCTEST_LOCK_MUTEX(mutex)
+            if(tc->m_no_output)
+                return;
+
             logTestStart();
 
-            file_line_to_stream(s, tc->m_file, tc->m_line, " ");
+            file_line_to_stream(tc->m_file.c_str(), tc->m_line, " ");
             successOrFailColoredStringToStream(false, e.is_crash ? assertType::is_require :
                                                                    assertType::is_check);
             s << Color::Red << (e.is_crash ? "test case CRASHED: " : "test case THREW exception: ")
@@ -5256,71 +6290,41 @@ namespace {
         }
 
         void subcase_start(const SubcaseSignature& subc) override {
-            std::lock_guard<std::mutex> lock(mutex);
             subcasesStack.push_back(subc);
+            ++currentSubcaseLevel;
             hasLoggedCurrentTestStart = false;
         }
 
         void subcase_end() override {
-            std::lock_guard<std::mutex> lock(mutex);
-            subcasesStack.pop_back();
+            --currentSubcaseLevel;
             hasLoggedCurrentTestStart = false;
         }
 
         void log_assert(const AssertData& rb) override {
-            if(!rb.m_failed && !opt.success)
+            if((!rb.m_failed && !opt.success) || tc->m_no_output)
                 return;
 
-            std::lock_guard<std::mutex> lock(mutex);
+            DOCTEST_LOCK_MUTEX(mutex)
 
             logTestStart();
 
-            file_line_to_stream(s, rb.m_file, rb.m_line, " ");
+            file_line_to_stream(rb.m_file, rb.m_line, " ");
             successOrFailColoredStringToStream(!rb.m_failed, rb.m_at);
-            if((rb.m_at & (assertType::is_throws_as | assertType::is_throws_with)) ==
-               0) //!OCLINT bitwise operator in conditional
-                s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << " ) "
-                  << Color::None;
 
-            if(rb.m_at & assertType::is_throws) { //!OCLINT bitwise operator in conditional
-                s << (rb.m_threw ? "threw as expected!" : "did NOT throw at all!") << "\n";
-            } else if(rb.m_at &
-                      assertType::is_throws_as) { //!OCLINT bitwise operator in conditional
-                s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", "
-                  << rb.m_exception_type << " ) " << Color::None
-                  << (rb.m_threw ? (rb.m_threw_as ? "threw as expected!" :
-                                                    "threw a DIFFERENT exception: ") :
-                                   "did NOT throw at all!")
-                  << Color::Cyan << rb.m_exception << "\n";
-            } else if(rb.m_at &
-                      assertType::is_throws_with) { //!OCLINT bitwise operator in conditional
-                s << Color::Cyan << assertString(rb.m_at) << "( " << rb.m_expr << ", \""
-                  << rb.m_exception_type << "\" ) " << Color::None
-                  << (rb.m_threw ? (!rb.m_failed ? "threw as expected!" :
-                                                   "threw a DIFFERENT exception: ") :
-                                   "did NOT throw at all!")
-                  << Color::Cyan << rb.m_exception << "\n";
-            } else if(rb.m_at & assertType::is_nothrow) { //!OCLINT bitwise operator in conditional
-                s << (rb.m_threw ? "THREW exception: " : "didn't throw!") << Color::Cyan
-                  << rb.m_exception << "\n";
-            } else {
-                s << (rb.m_threw ? "THREW exception: " :
-                                   (!rb.m_failed ? "is correct!\n" : "is NOT correct!\n"));
-                if(rb.m_threw)
-                    s << rb.m_exception << "\n";
-                else
-                    s << "  values: " << assertString(rb.m_at) << "( " << rb.m_decomp << " )\n";
-            }
+            fulltext_log_assert_to_stream(s, rb);
 
             log_contexts();
         }
 
         void log_message(const MessageData& mb) override {
-            std::lock_guard<std::mutex> lock(mutex);
+            if(tc->m_no_output)
+                return;
+
+            DOCTEST_LOCK_MUTEX(mutex)
 
             logTestStart();
 
-            file_line_to_stream(s, mb.m_file, mb.m_line, " ");
+            file_line_to_stream(mb.m_file, mb.m_line, " ");
             s << getSuccessOrFailColor(false, mb.m_severity)
               << getSuccessOrFailString(mb.m_severity & assertType::is_warn, mb.m_severity,
                                         "MESSAGE") << ": ";
@@ -5346,14 +6350,17 @@ namespace {
         bool with_col = g_no_colors;                                                               \
         g_no_colors   = false;                                                                     \
         ConsoleReporter::func(arg);                                                                \
-        DOCTEST_OUTPUT_DEBUG_STRING(oss.str().c_str());                                            \
-        oss.str("");                                                                               \
+        if(oss.tellp() != std::streampos{}) {                                                      \
+            DOCTEST_OUTPUT_DEBUG_STRING(oss.str().c_str());                                        \
+            oss.str("");                                                                           \
+        }                                                                                          \
         g_no_colors = with_col;                                                                    \
     }
 
         DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_run_start, DOCTEST_EMPTY, DOCTEST_EMPTY)
         DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_run_end, const TestRunStats&, in)
         DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_start, const TestCaseData&, in)
+        DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_reenter, const TestCaseData&, in)
         DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_end, const CurrentTestCaseStats&, in)
         DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(test_case_exception, const TestCaseException&, in)
         DOCTEST_DEBUG_OUTPUT_REPORTER_OVERRIDE(subcase_start, const SubcaseSignature&, in)
@@ -5368,7 +6375,7 @@ namespace {
 
     // the implementation of parseOption()
     bool parseOptionImpl(int argc, const char* const* argv, const char* pattern, String* value) {
-        // going from the end to the begining and stopping on the first occurance from the end
+        // going from the end to the beginning and stopping on the first occurrence from the end
         for(int i = argc; i > 0; --i) {
             auto index = i - 1;
             auto temp = std::strstr(argv[index], pattern);
@@ -5424,18 +6431,42 @@ namespace {
                            std::vector<String>& res) {
         String filtersString;
         if(parseOption(argc, argv, pattern, &filtersString)) {
-            // tokenize with "," as a separator
-            // cppcheck-suppress strtokCalled
-            DOCTEST_CLANG_SUPPRESS_WARNING_WITH_PUSH("-Wdeprecated-declarations")
-            auto pch = std::strtok(filtersString.c_str(), ","); // modifies the string
-            while(pch != nullptr) {
-                if(strlen(pch))
-                    res.push_back(pch);
-                // uses the strtok() internal state to go to the next token
-                // cppcheck-suppress strtokCalled
-                pch = std::strtok(nullptr, ",");
+            // tokenize with "," as a separator, unless escaped with backslash
+            std::ostringstream s;
+            auto flush = [&s, &res]() {
+                auto string = s.str();
+                if(string.size() > 0) {
+                    res.push_back(string.c_str());
+                }
+                s.str("");
+            };
+
+            bool seenBackslash = false;
+            const char* current = filtersString.c_str();
+            const char* end = current + strlen(current);
+            while(current != end) {
+                char character = *current++;
+                if(seenBackslash) {
+                    seenBackslash = false;
+                    if(character == ',' || character == '\\') {
+                        s.put(character);
+                        continue;
+                    }
+                    s.put('\\');
+                }
+                if(character == '\\') {
+                    seenBackslash = true;
+                } else if(character == ',') {
+                    flush();
+                } else {
+                    s.put(character);
+                }
             }
-            DOCTEST_CLANG_SUPPRESS_WARNING_POP
+
+            if(seenBackslash) {
+                s.put('\\');
+            }
+            flush();
             return true;
         }
         return false;
@@ -5454,29 +6485,29 @@ namespace {
         if(!parseOption(argc, argv, pattern, &parsedValue))
             return false;
 
-        if(type == 0) {
+        if(type) {
+            // integer
+            // TODO: change this to use std::stoi or something else! currently it uses undefined behavior - assumes '0' on failed parse...
+            int theInt = std::atoi(parsedValue.c_str());
+            if (theInt != 0) {
+                res = theInt; //!OCLINT parameter reassignment
+                return true;
+            }
+        } else {
             // boolean
-            const char positive[][5] = {"1", "true", "on", "yes"};  // 5 - strlen("true") + 1
-            const char negative[][6] = {"0", "false", "off", "no"}; // 6 - strlen("false") + 1
+            const char positive[][5] = { "1", "true", "on", "yes" };  // 5 - strlen("true") + 1
+            const char negative[][6] = { "0", "false", "off", "no" }; // 6 - strlen("false") + 1
 
             // if the value matches any of the positive/negative possibilities
-            for(unsigned i = 0; i < 4; i++) {
-                if(parsedValue.compare(positive[i], true) == 0) {
+            for (unsigned i = 0; i < 4; i++) {
+                if (parsedValue.compare(positive[i], true) == 0) {
                     res = 1; //!OCLINT parameter reassignment
                     return true;
                 }
-                if(parsedValue.compare(negative[i], true) == 0) {
+                if (parsedValue.compare(negative[i], true) == 0) {
                     res = 0; //!OCLINT parameter reassignment
                     return true;
                 }
-            }
-        } else {
-            // integer
-            // TODO: change this to use std::stoi or something else! currently it uses undefined behavior - assumes '0' on failed parse...
-            int theInt = std::atoi(parsedValue.c_str()); // NOLINT
-            if(theInt != 0) {
-                res = theInt; //!OCLINT parameter reassignment
-                return true;
             }
         }
         return false;
@@ -5533,7 +6564,7 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
 #define DOCTEST_PARSE_AS_BOOL_OR_FLAG(name, sname, var, default)                                   \
     if(parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name "=", option_bool, intRes) ||  \
        parseIntOption(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname "=", option_bool, intRes))   \
-        p->var = !!intRes;                                                                         \
+        p->var = static_cast<bool>(intRes);                                                        \
     else if(parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX name) ||                           \
             parseFlag(argc, argv, DOCTEST_CONFIG_OPTIONS_PREFIX sname))                            \
         p->var = true;                                                                             \
@@ -5568,9 +6599,12 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("case-sensitive", "cs", case_sensitive, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("exit", "e", exit, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("duration", "d", duration, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("minimal", "m", minimal, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("quiet", "q", quiet, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-throw", "nt", no_throw, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-exitcode", "ne", no_exitcode, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-run", "nr", no_run, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-intro", "ni", no_intro, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-version", "nv", no_version, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-colors", "nc", no_colors, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("force-colors", "fc", force_colors, false);
@@ -5579,7 +6613,9 @@ void Context::parseArgs(int argc, const char* const* argv, bool withDefaults) {
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("gnu-file-line", "gfl", gnu_file_line, !bool(DOCTEST_MSVC));
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-path-filenames", "npf", no_path_in_filenames, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-line-numbers", "nln", no_line_numbers, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-debug-output", "ndo", no_debug_output, false);
     DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-skipped-summary", "nss", no_skipped_summary, false);
+    DOCTEST_PARSE_AS_BOOL_OR_FLAG("no-time-in-output", "ntio", no_time_in_output, false);
     // clang-format on
 
     if(withDefaults) {
@@ -5632,7 +6668,12 @@ void Context::clearFilters() {
         curr.clear();
 }
 
-// allows the user to override procedurally the int/bool options from the command line
+// allows the user to override procedurally the bool options from the command line
+void Context::setOption(const char* option, bool value) {
+    setOption(option, value ? "true" : "false");
+}
+
+// allows the user to override procedurally the int options from the command line
 void Context::setOption(const char* option, int value) {
     setOption(option, toString(value).c_str());
 }
@@ -5651,6 +6692,31 @@ void Context::setAsDefaultForAssertsOutOfTestCases() { g_cs = p; }
 
 void Context::setAssertHandler(detail::assert_handler ah) { p->ah = ah; }
 
+void Context::setCout(std::ostream* out) { p->cout = out; }
+
+static class DiscardOStream : public std::ostream
+{
+private:
+    class : public std::streambuf
+    {
+    private:
+        // allowing some buffering decreases the amount of calls to overflow
+        char buf[1024];
+
+    protected:
+        std::streamsize xsputn(const char_type*, std::streamsize count) override { return count; }
+
+        int_type overflow(int_type ch) override {
+            setp(std::begin(buf), std::end(buf));
+            return traits_type::not_eof(ch);
+        }
+    } discardBuf;
+
+public:
+    DiscardOStream()
+            : std::ostream(&discardBuf) {}
+} discardOut;
+
 // the main function that does all the filtering and test running
 int Context::run() {
     using namespace detail;
@@ -5664,18 +6730,25 @@ int Context::run() {
     g_no_colors = p->no_colors;
     p->resetRunData();
 
-    // stdout by default
-    p->cout = &std::cout;
-    p->cerr = &std::cerr;
-
-    // or to a file if specified
     std::fstream fstr;
-    if(p->out.size()) {
-        fstr.open(p->out.c_str(), std::fstream::out);
-        p->cout = &fstr;
+    if(p->cout == nullptr) {
+        if(p->quiet) {
+            p->cout = &discardOut;
+        } else if(p->out.size()) {
+            // to a file if specified
+            fstr.open(p->out.c_str(), std::fstream::out);
+            p->cout = &fstr;
+        } else {
+            // stdout by default
+            p->cout = &std::cout;
+        }
     }
 
+    FatalConditionHandler::allocateAltStackMem();
+
     auto cleanup_and_return = [&]() {
+        FatalConditionHandler::freeAltStackMem();
+
         if(fstr.is_open())
             fstr.close();
 
@@ -5710,7 +6783,7 @@ int Context::run() {
         p->reporters_currently_used.insert(p->reporters_currently_used.begin(), curr.second(*g_cs));
 
 #ifdef DOCTEST_PLATFORM_WINDOWS
-    if(isDebuggerActive())
+    if(isDebuggerActive() && p->no_debug_output == false)
         p->reporters_currently_used.push_back(new DebugOutputWindowReporter(*g_cs));
 #endif // DOCTEST_PLATFORM_WINDOWS
 
@@ -5740,20 +6813,23 @@ int Context::run() {
             // random_shuffle implementation
             const auto first = &testArray[0];
             for(size_t i = testArray.size() - 1; i > 0; --i) {
-                int idxToSwap = std::rand() % (i + 1); // NOLINT
+                int idxToSwap = std::rand() % (i + 1);
 
                 const auto temp = first[i];
 
                 first[i]         = first[idxToSwap];
                 first[idxToSwap] = temp;
             }
+        } else if(p->order_by.compare("none", true) == 0) {
+            // means no sorting - beneficial for death tests which call into the executable
+            // with a specific test case in mind - we don't want to slow down the startup times
         }
     }
 
     std::set<String> testSuitesPassingFilt;
 
-    bool                query_mode = p->count || p->list_test_cases || p->list_test_suites;
-    std::vector<String> queryResults;
+    bool                             query_mode = p->count || p->list_test_cases || p->list_test_suites;
+    std::vector<const TestCaseData*> queryResults;
 
     if(!query_mode)
         DOCTEST_ITERATE_THROUGH_REPORTERS(test_run_start, DOCTEST_EMPTY);
@@ -5766,9 +6842,9 @@ int Context::run() {
         if(tc.m_skip && !p->no_skip)
             skip_me = true;
 
-        if(!matchesAny(tc.m_file, p->filters[0], true, p->case_sensitive))
+        if(!matchesAny(tc.m_file.c_str(), p->filters[0], true, p->case_sensitive))
             skip_me = true;
-        if(matchesAny(tc.m_file, p->filters[1], false, p->case_sensitive))
+        if(matchesAny(tc.m_file.c_str(), p->filters[1], false, p->case_sensitive))
             skip_me = true;
         if(!matchesAny(tc.m_test_suite, p->filters[2], true, p->case_sensitive))
             skip_me = true;
@@ -5799,14 +6875,14 @@ int Context::run() {
 
         // print the name of the test and don't execute it
         if(p->list_test_cases) {
-            queryResults.push_back(tc.m_name);
+            queryResults.push_back(&tc);
             continue;
         }
 
         // print the name of the test suite if not done already and don't execute it
         if(p->list_test_suites) {
             if((testSuitesPassingFilt.count(tc.m_test_suite) == 0) && tc.m_test_suite[0] != '\0') {
-                queryResults.push_back(tc.m_test_suite);
+                queryResults.push_back(&tc);
                 testSuitesPassingFilt.insert(tc.m_test_suite);
                 p->numTestSuitesPassingFilters++;
             }
@@ -5824,17 +6900,22 @@ int Context::run() {
             p->numAssertsFailedCurrentTest_atomic = 0;
             p->numAssertsCurrentTest_atomic       = 0;
 
-            p->subcasesPassed.clear();
+            p->fullyTraversedSubcases.clear();
 
             DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_start, tc);
 
             p->timer.start();
+            
+            bool run_test = true;
 
             do {
                 // reset some of the fields for subcases (except for the set of fully passed ones)
-                p->should_reenter       = false;
-                p->subcasesCurrentLevel = 0;
-                p->subcasesEnteredLevels.clear();
+                p->reachedLeaf = false;
+                // May not be empty if previous subcase exited via exception.
+                p->subcaseStack.clear();
+                p->currentSubcaseDepth = 0;
+
+                p->shouldLogCurrentException = true;
 
                 // reset stuff for logging with INFO()
                 p->stringifiedContexts.clear();
@@ -5842,10 +6923,13 @@ int Context::run() {
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
                 try {
 #endif // DOCTEST_CONFIG_NO_EXCEPTIONS
+// MSVC 2015 diagnoses fatalConditionHandler as unused (because reset() is a static method)
+DOCTEST_MSVC_SUPPRESS_WARNING_WITH_PUSH(4101) // unreferenced local variable
                     FatalConditionHandler fatalConditionHandler; // Handle signals
                     // execute the test
                     tc.m_test();
                     fatalConditionHandler.reset();
+DOCTEST_MSVC_SUPPRESS_WARNING_POP
 #ifndef DOCTEST_CONFIG_NO_EXCEPTIONS
                 } catch(const TestFailureException&) {
                     p->failure_flags |= TestCaseFailureReason::AssertFailure;
@@ -5859,10 +6943,15 @@ int Context::run() {
                 // exit this loop if enough assertions have failed - even if there are more subcases
                 if(p->abort_after > 0 &&
                    p->numAssertsFailed + p->numAssertsFailedCurrentTest_atomic >= p->abort_after) {
-                    p->should_reenter = false;
+                    run_test = false;
                     p->failure_flags |= TestCaseFailureReason::TooManyFailedAsserts;
                 }
-            } while(p->should_reenter == true);
+                
+                if(!p->nextSubcaseStack.empty() && run_test)
+                    DOCTEST_ITERATE_THROUGH_REPORTERS(test_case_reenter, tc);
+                if(p->nextSubcaseStack.empty())
+                    run_test = false;
+            } while(run_test);
 
             p->finalizeTestCaseData();
 
@@ -5886,21 +6975,10 @@ int Context::run() {
         DOCTEST_ITERATE_THROUGH_REPORTERS(report_query, qdata);
     }
 
-    // see these issues on the reasoning for this:
-    // - https://github.com/onqtam/doctest/issues/143#issuecomment-414418903
-    // - https://github.com/onqtam/doctest/issues/126
-    auto DOCTEST_FIX_FOR_MACOS_LIBCPP_IOSFWD_STRING_LINK_ERRORS = []() DOCTEST_NOINLINE
-        { std::cout << std::string(); };
-    DOCTEST_FIX_FOR_MACOS_LIBCPP_IOSFWD_STRING_LINK_ERRORS();
-
     return cleanup_and_return();
 }
 
-DOCTEST_DEFINE_DEFAULTS(CurrentTestCaseStats);
-
-DOCTEST_DEFINE_DEFAULTS(TestRunStats);
-
-IReporter::~IReporter() = default;
+DOCTEST_DEFINE_INTERFACE(IReporter)
 
 int IReporter::get_num_active_contexts() { return detail::g_infoContexts.size(); }
 const IContextScope* const* IReporter::get_active_contexts() {
@@ -5934,6 +7012,8 @@ DOCTEST_MSVC_SUPPRESS_WARNING_POP
 DOCTEST_CLANG_SUPPRESS_WARNING_POP
 DOCTEST_MSVC_SUPPRESS_WARNING_POP
 DOCTEST_GCC_SUPPRESS_WARNING_POP
+
+DOCTEST_SUPPRESS_COMMON_WARNINGS_POP
 
 #endif // DOCTEST_LIBRARY_IMPLEMENTATION
 #endif // DOCTEST_CONFIG_IMPLEMENT


### PR DESCRIPTION
The current version did not build on my computer (new-ish Apple) so I updated  ApprovalTest.hpp and Doctest to newer versions. (Bug-reports suggested an update.)

Both files are sourced from their official sites. 

ApprovalTest seemed to be looking for doctest in a doctest-folder, so i created one and moved it into it. 

I am also not that good with cpp-namespaces yet, and then a rather err on the side of being explicit, so I added them to the function calls in order to get ApprovalTest to work in the test. 

