### PR TITLE
Fix python implementation with recent versions of dependencies

### DIFF
--- a/python/tests/test_statement.py
+++ b/python/tests/test_statement.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 from approvaltests import verify
-from approvaltests.utils import get_adjacent_file
+from approval_utilities.utils import get_adjacent_file
 
 from statement import statement
 


### PR DESCRIPTION
I just tried the python version, and it seems that the way to import `get_adjacent_file` has changed (there is no pinned version in `requirements.txt` so by default the most recent version is used).

Pytest was also failing on `from statement import statement`, which got solved by adding `__init__.py` in the test directory.