### PR TITLE
Fix ruby implementation

### DIFF
--- a/ruby/lib/theatrical_plays/statement.rb
+++ b/ruby/lib/theatrical_plays/statement.rb
@@ -30,7 +30,7 @@ def statement(invoice, plays)
     # add volume credits
     volume_credits += [perf['audience'] - 30, 0].max
     # add extra credit for every ten comedy attendees
-    if play[:type] == 'comedy'
+    if play['type'] == 'comedy'
       volume_credits += (perf['audience'] / 5).floor
     end
 

--- a/ruby/test/statement_test.rb
+++ b/ruby/test/statement_test.rb
@@ -12,7 +12,7 @@ class TestStatement < Minitest::Test
     " As You Like It: $580.00 (35 seats)\n" \
     " Othello: $500.00 (40 seats)\n" \
     "Amount owed is $1730.00\n" \
-    "You earned 40 credits\n"
+    "You earned 47 credits\n"
 
     assert_equal expected_statement, statement(invoice, plays)
   end


### PR DESCRIPTION
I discovered a bug in the ruby implementation that was incorrectly calculating the credits when the play has a type of `comedy`. The conditional was using a Symbol to lookup the type in the play, but the provided hash has string keys. The test data was asserting an incorrect value, I updated it as well to expect 47 credits which seemed consistent with the other language implementations