### PR TITLE
Restructure C++ CMake build targets

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,6 +1,22 @@
 cmake_minimum_required(VERSION 3.4)
-project(theatrical_players_refactoring_kata)
+project(theatrical_players_refactoring_kata
+    LANGUAGES CXX
+)
 
 set(CMAKE_CXX_STANDARD 11)
 
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
+add_library(theatrical_players_lib STATIC
+    "statement.cpp"
+    "statement.h"
+)
+
+target_include_directories(
+    theatrical_players_lib
+    PUBLIC
+    third_party
+)
+
+enable_testing()
 add_subdirectory(tests)

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -1,15 +1,20 @@
-project(tests)
-
-add_executable(${PROJECT_NAME}
-    ../statement.cpp
-    ../statement.h
+add_executable(tests
     test_statement.cpp
-    main.cpp)
+)
 
 target_include_directories(
-    ${PROJECT_NAME}
+    tests
     PUBLIC
-    ../third_party ..)
+    ../third_party
+    ..
+)
 
-enable_testing()
-add_test(NAME ${PROJECT_NAME}_test COMMAND ${PROJECT_NAME})
+target_link_libraries(tests
+    PRIVATE theatrical_players_lib
+)
+
+add_test(
+    NAME ${PROJECT_NAME}_test
+    COMMAND tests
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/cpp/tests/main.cpp
+++ b/cpp/tests/main.cpp
@@ -1,2 +1,0 @@
-#define APPROVALS_DOCTEST
-#include "ApprovalTests.hpp"

--- a/cpp/tests/test_statement.cpp
+++ b/cpp/tests/test_statement.cpp
@@ -1,7 +1,9 @@
 #include "statement.h"
 
 #include "json.hpp"
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include "doctest/doctest.h"
+#define APPROVALS_DOCTEST
 #include "ApprovalTests.hpp"
 
 #include <iostream>


### PR DESCRIPTION
As briefly mentioned at the #OOPMUC this PR restructures the CMake build targets to have a library and its corresponding approval test which is more realistic than having just one test target. It's now similar to the C language variant.