### PR TITLE
Fix C++ CMake deprecation warning

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.4...3.14)
 project(theatrical_players_refactoring_kata
     LANGUAGES CXX
 )


### PR DESCRIPTION
Fix CMake deprecation warning that "Compatibility with CMake < 3.5 will be removed from a future version of CMake"