### PR TITLE
fix php top level readme link

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -1,6 +1,6 @@
 # Theatrical Players Refactoring Kata - PHP version
 
-See the [top level readme](../../Theatrical-Players-Refactoring-Kata/README.md) for general information
+See the [top level readme](../README.md) for general information
  about this exercise. This is the PHP version of the Theatrical Players Refactoring Kata. Download the PDF of the first 
 chapter of ['Refactoring' by Martin Fowler, 2nd Edition](https://www.thoughtworks.com/books/refactoring2) which contains 
 a worked example of this exercise, in javascript.


### PR DESCRIPTION
fixes the 404 error on the [php readme.md](https://github.com/emilybache/Theatrical-Players-Refactoring-Kata/blob/main/php/README.md) top level readme.

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/4b891282-9517-4e6c-9cd1-882c517d8a34" />
