### PR TITLE
[ruby] Add `Gemfile.lock` to `.gitignore`

### DIFF
--- a/ruby/.gitignore
+++ b/ruby/.gitignore
@@ -1,0 +1,1 @@
+Gemfile.lock


### PR DESCRIPTION
Running `bundle` causes this to be generated.

Similar to https://github.com/emilybache/Parrot-Refactoring-Kata/pull/55