### PR TITLE
[ruby] Don't rescue `Exception` instances

### DIFF
--- a/ruby/test/statement_test.rb
+++ b/ruby/test/statement_test.rb
@@ -21,7 +21,7 @@ class TestStatement < Minitest::Test
     invoice = load_json_fixture('invoice_new_plays.json')
     plays = load_json_fixture('new_plays.json')
 
-    error = assert_raises(Exception) do
+    error = assert_raises(StandardError) do
       statement(invoice, plays)
     end
 


### PR DESCRIPTION
Rescuing `Exception` in Ruby is usually a bad idea, since even things like syntax errors or interrupts inherit from `Exception`.

Reference: [Rescuing Exceptions is not idiomatic](https://thoughtbot.com/blog/rescue-standarderror-not-exception#rescuing-exceptions-is-not-idiomatic)

