### PR TITLE
[Java] Fix string formatting to use platform-specific line separator

### DIFF
--- a/java/src/main/java/theatricalplays/StatementPrinter.java
+++ b/java/src/main/java/theatricalplays/StatementPrinter.java
@@ -9,7 +9,7 @@ public class StatementPrinter {
     public String print(Invoice invoice, Map<String, Play> plays) {
         var totalAmount = 0;
         var volumeCredits = 0;
-        var result = String.format("Statement for %s\n", invoice.customer);
+        var result = String.format("Statement for %s%n", invoice.customer);
 
         NumberFormat frmt = NumberFormat.getCurrencyInstance(Locale.US);
 
@@ -41,11 +41,11 @@ public class StatementPrinter {
             if ("comedy".equals(play.type)) volumeCredits += Math.floor(perf.audience / 5);
 
             // print line for this order
-            result += String.format("  %s: %s (%s seats)\n", play.name, frmt.format(thisAmount / 100), perf.audience);
+            result += String.format("  %s: %s (%s seats)%n", play.name, frmt.format(thisAmount / 100), perf.audience);
             totalAmount += thisAmount;
         }
-        result += String.format("Amount owed is %s\n", frmt.format(totalAmount / 100));
-        result += String.format("You earned %s credits\n", volumeCredits);
+        result += String.format("Amount owed is %s%n", frmt.format(totalAmount / 100));
+        result += String.format("You earned %s credits%n", volumeCredits);
         return result;
     }
 


### PR DESCRIPTION
Fix the SonarQube issue "Format strings should be used correctly" (java:S3457)

See https://next.sonarqube.com/sonarqube/coding_rules?open=java%3AS3457&rule_key=java%3AS3457

> "%n should be used in place of \n to produce the platform-specific line separator."